### PR TITLE
feat: 時刻表原文をブラウザで開く機能を追加

### DIFF
--- a/flutter_app/android/app/src/main/AndroidManifest.xml
+++ b/flutter_app/android/app/src/main/AndroidManifest.xml
@@ -58,5 +58,13 @@
             <action android:name="android.intent.action.PROCESS_TEXT"/>
             <data android:mimeType="text/plain"/>
         </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW"/>
+            <data android:scheme="https"/>
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW"/>
+            <data android:scheme="http"/>
+        </intent>
     </queries>
 </manifest>

--- a/flutter_app/lib/data/models/bus_schedule_model.dart
+++ b/flutter_app/lib/data/models/bus_schedule_model.dart
@@ -63,6 +63,7 @@ extension BusTimetableModelMapper on BusTimetableModel {
         validFrom: validFrom,
         validTo: validTo,
         schedules: schedules.map((e) => e.toEntity()).toList(),
+        pdfUrl: pdfUrl,
       );
 }
 

--- a/flutter_app/lib/domain/entities/bus_schedule.dart
+++ b/flutter_app/lib/domain/entities/bus_schedule.dart
@@ -43,11 +43,13 @@ class BusTimetable {
     required this.validFrom,
     required this.validTo,
     required this.schedules,
+    this.pdfUrl = '',
   });
 
   final String validFrom;
   final String validTo;
   final List<BusEntry> schedules;
+  final String pdfUrl;
 
   BusEntry? nextBus(BusDirection direction, {DateTime? now}) {
     final current = now ?? DateTime.now();

--- a/flutter_app/lib/presentation/views/home_screen.dart
+++ b/flutter_app/lib/presentation/views/home_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:url_launcher/url_launcher.dart';
 import '../../domain/entities/bus_schedule.dart';
 import '../viewmodels/notification_viewmodel.dart';
 import '../viewmodels/schedule_viewmodel.dart';
@@ -50,6 +51,20 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
           ),
         ),
         actions: [
+          scheduleAsync.maybeWhen(
+            data: (r) => r.current.pdfUrl.isNotEmpty
+                ? IconButton(
+                    icon: const Icon(Icons.open_in_browser,
+                        color: Color(0xFF00FF88)),
+                    tooltip: '時刻表原文を開く',
+                    onPressed: () => launchUrl(
+                      Uri.parse(r.current.pdfUrl),
+                      mode: LaunchMode.externalApplication,
+                    ),
+                  )
+                : const SizedBox.shrink(),
+            orElse: () => const SizedBox.shrink(),
+          ),
           scheduleAsync.maybeWhen(
             data: (r) => r.upcoming != null
                 ? IconButton(

--- a/flutter_app/pubspec.lock
+++ b/flutter_app/pubspec.lock
@@ -804,6 +804,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "767344bf3063897b5cf0db830e94f904528e6dd50a6dfaf839f0abf509009611"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.28"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.1"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.5"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: d0412fcf4c6b31ecfdb7762359b7206ffba3bbffd396c6d9f9c4616ece476c1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
   uuid:
     dependency: transitive
     description:
@@ -893,5 +957,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
-  flutter: ">=3.35.0"
+  dart: ">=3.10.0 <4.0.0"
+  flutter: ">=3.38.0"

--- a/flutter_app/pubspec.yaml
+++ b/flutter_app/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   flutter_local_notifications: ^18.0.0
   shared_preferences: ^2.3.0
   timezone: ^0.9.4
+  url_launcher: ^6.3.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary

Issue #7 の実装。AppBar の「原文を見る」ボタンで時刻表PDFをブラウザで開く。

- url_launcher パッケージを使用
- BusTimetable に pdfUrl フィールドを追加
- pdfUrl が設定されている場合のみボタンを表示

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)