### PR TITLE
feat: デバッグ用時刻オーバーライド機能を追加

### DIFF
--- a/flutter_app/lib/presentation/viewmodels/schedule_viewmodel.dart
+++ b/flutter_app/lib/presentation/viewmodels/schedule_viewmodel.dart
@@ -17,9 +17,11 @@ final scheduleViewModelProvider =
   ScheduleViewModel.new,
 );
 
+final debugTimeProvider = StateProvider<DateTime?>((ref) => null);
+
 final countdownProvider =
     StateNotifierProvider<CountdownNotifier, DateTime>((ref) {
-  return CountdownNotifier();
+  return CountdownNotifier(ref);
 });
 
 // ----- ScheduleViewModel -----
@@ -54,12 +56,13 @@ class ScheduleViewModel extends AsyncNotifier<ScheduleResponse> {
 // ----- CountdownNotifier -----
 
 class CountdownNotifier extends StateNotifier<DateTime> {
-  CountdownNotifier() : super(DateTime.now()) {
+  CountdownNotifier(this._ref) : super(DateTime.now()) {
     _timer = Timer.periodic(AppConstants.countdownRefreshInterval, (_) {
-      state = DateTime.now();
+      state = _ref.read(debugTimeProvider) ?? DateTime.now();
     });
   }
 
+  final Ref _ref;
   Timer? _timer;
 
   @override

--- a/flutter_app/lib/presentation/views/home_screen.dart
+++ b/flutter_app/lib/presentation/views/home_screen.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../domain/entities/bus_schedule.dart';
@@ -47,6 +48,23 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
           ),
         ),
         actions: [
+          if (kDebugMode) ...[
+            Consumer(builder: (context, ref, _) {
+              final debugTime = ref.watch(debugTimeProvider);
+              return IconButton(
+                icon: Icon(
+                  Icons.access_time,
+                  color: debugTime != null
+                      ? const Color(0xFFFFB000)
+                      : const Color(0xFF444444),
+                ),
+                tooltip: debugTime != null
+                    ? '時刻オーバーライド中 (タップでリセット/変更)'
+                    : 'デバッグ: 時刻を設定',
+                onPressed: () => _onDebugTimeTap(context, ref, debugTime),
+              );
+            }),
+          ],
           scheduleAsync.maybeWhen(
             data: (r) => r.upcoming != null
                 ? IconButton(
@@ -107,6 +125,61 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
           ],
         ),
       ),
+    );
+  }
+
+  Future<void> _onDebugTimeTap(
+      BuildContext context, WidgetRef ref, DateTime? current) async {
+    if (current != null) {
+      // オーバーライド中: リセットか変更かを選択
+      final choice = await showDialog<String>(
+        context: context,
+        builder: (ctx) => AlertDialog(
+          backgroundColor: const Color(0xFF1A1A1A),
+          title: const Text('時刻オーバーライド',
+              style: TextStyle(color: Color(0xFF00FF88))),
+          content: Text(
+            '現在: ${current.hour.toString().padLeft(2, '0')}:${current.minute.toString().padLeft(2, '0')}',
+            style: const TextStyle(color: Color(0xFFCCCCCC)),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(ctx, 'reset'),
+              child: const Text('リセット',
+                  style: TextStyle(color: Color(0xFFFF4444))),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(ctx, 'change'),
+              child: const Text('変更',
+                  style: TextStyle(color: Color(0xFFFFB000))),
+            ),
+          ],
+        ),
+      );
+      if (choice == 'reset') {
+        ref.read(debugTimeProvider.notifier).state = null;
+        return;
+      }
+      if (choice != 'change') return;
+    }
+
+    // 時刻ピッカーを表示
+    if (!context.mounted) return;
+    final picked = await showTimePicker(
+      context: context,
+      initialTime: current != null
+          ? TimeOfDay(hour: current.hour, minute: current.minute)
+          : TimeOfDay.now(),
+    );
+    if (picked == null) return;
+
+    final now = DateTime.now();
+    ref.read(debugTimeProvider.notifier).state = DateTime(
+      now.year,
+      now.month,
+      now.day,
+      picked.hour,
+      picked.minute,
     );
   }
 

--- a/flutter_app/test/helpers/test_theme.dart
+++ b/flutter_app/test/helpers/test_theme.dart
@@ -17,7 +17,7 @@ final kTestNow = DateTime(2024, 1, 1, 9, 0);
 
 /// countdownProviderを固定時刻にオーバーライドするOverride
 Override countdownOverride({DateTime? now}) => countdownProvider.overrideWith(
-      (ref) => CountdownNotifier()..state = now ?? kTestNow,
+      (ref) => CountdownNotifier(ref)..state = now ?? kTestNow,
     );
 
 /// [now] から [minutesAhead] 分後のHH:MM文字列を返す（日付跨ぎを23:58にキャップ）

--- a/flutter_app/test/unit/presentation/countdown_notifier_test.dart
+++ b/flutter_app/test/unit/presentation/countdown_notifier_test.dart
@@ -1,13 +1,16 @@
 import 'package:fake_async/fake_async.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:chitose_bus/presentation/viewmodels/schedule_viewmodel.dart';
 
 void main() {
   group('CountdownNotifier', () {
     test('initial state is close to DateTime.now()', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
       final before = DateTime.now();
-      final notifier = CountdownNotifier();
-      addTearDown(notifier.dispose);
+      final notifier = container.read(countdownProvider.notifier);
       final after = DateTime.now();
 
       expect(
@@ -19,33 +22,36 @@ void main() {
 
     test('state updates after countdownRefreshInterval elapses', () {
       fakeAsync((async) {
-        final notifier = CountdownNotifier();
+        final container = ProviderContainer();
+        final notifier = container.read(countdownProvider.notifier);
         final initial = notifier.state;
 
         // Advance fake clock by 30 seconds (countdownRefreshInterval)
         async.elapse(const Duration(seconds: 30));
 
         expect(notifier.state.isAfter(initial), isTrue);
-        notifier.dispose();
+        container.dispose();
       });
     });
 
     test('state does not update before interval elapses', () {
       fakeAsync((async) {
-        final notifier = CountdownNotifier();
+        final container = ProviderContainer();
+        final notifier = container.read(countdownProvider.notifier);
         final initial = notifier.state;
 
         // Advance by less than the interval
         async.elapse(const Duration(seconds: 29));
 
         expect(notifier.state, equals(initial));
-        notifier.dispose();
+        container.dispose();
       });
     });
 
     test('state updates multiple times over multiple intervals', () {
       fakeAsync((async) {
-        final notifier = CountdownNotifier();
+        final container = ProviderContainer();
+        final notifier = container.read(countdownProvider.notifier);
         final initialState = notifier.state;
 
         // Verify each of 3 successive intervals triggers a state update.
@@ -61,7 +67,7 @@ void main() {
         final stateAfter3 = notifier.state;
         expect(stateAfter3.isAfter(stateAfter2), isTrue); // 3rd update
 
-        notifier.dispose();
+        container.dispose();
       });
     });
   });

--- a/flutter_app/test/widget/golden/next_bus_card_golden_test.dart
+++ b/flutter_app/test/widget/golden/next_bus_card_golden_test.dart
@@ -52,7 +52,7 @@ void main() {
       ProviderScope(
         overrides: [
           countdownProvider.overrideWith(
-            (ref) => CountdownNotifier()..state = DateTime(2024, 1, 1, 9, 0),
+            (ref) => CountdownNotifier(ref)..state = DateTime(2024, 1, 1, 9, 0),
           ),
         ],
         child: _buildTestApp(
@@ -79,7 +79,7 @@ void main() {
       ProviderScope(
         overrides: [
           countdownProvider.overrideWith(
-            (ref) => CountdownNotifier()..state = DateTime(2024, 1, 1, 23, 59),
+            (ref) => CountdownNotifier(ref)..state = DateTime(2024, 1, 1, 23, 59),
           ),
         ],
         child: _buildTestApp(

--- a/flutter_app/test/widget/golden/schedule_list_golden_test.dart
+++ b/flutter_app/test/widget/golden/schedule_list_golden_test.dart
@@ -73,7 +73,7 @@ void main() {
       ProviderScope(
         overrides: [
           countdownProvider.overrideWith(
-            (ref) => CountdownNotifier()..state = DateTime(2024, 1, 1, 9, 0),
+            (ref) => CountdownNotifier(ref)..state = DateTime(2024, 1, 1, 9, 0),
           ),
         ],
         child: _buildTestApp(
@@ -101,7 +101,7 @@ void main() {
         overrides: [
           countdownProvider.overrideWith(
             (ref) =>
-                CountdownNotifier()..state = DateTime(2024, 1, 1, 23, 59),
+                CountdownNotifier(ref)..state = DateTime(2024, 1, 1, 23, 59),
           ),
         ],
         child: _buildTestApp(


### PR DESCRIPTION
## Summary

デバッグビルド時に AppBar の時計アイコンから現在時刻を任意の時刻に上書きできる機能。

- `debugTimeProvider`: `StateProvider<DateTime?>` で時刻を管理
- `CountdownNotifier` が `debugTimeProvider` を優先参照
- `kDebugMode` ガードでリリースビルドには影響なし
- オーバーライド中はアイコンをアンバー色で強調表示
- 再タップでリセット or 変更のダイアログを表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)