### PR TITLE
fix: add scripts for MobAI iOS dev with dart-defines

### DIFF
--- a/scripts/dev_flutter.sh
+++ b/scripts/dev_flutter.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# dev_flutter.sh
+# scripts/flutter ラッパーを PATH に差し込んだ上で builder dev flutter を実行する
+# これにより builder が内部で呼ぶ flutter attach に --dart-define-from-file が付与される
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+chmod +x "$SCRIPT_DIR/flutter"
+
+exec env PATH="$SCRIPT_DIR:$PATH" /usr/local/bin/builder dev flutter "$@"

--- a/scripts/flutter
+++ b/scripts/flutter
@@ -1,0 +1,18 @@
+#!/bin/bash
+# flutter wrapper
+# builder dev flutter が内部で flutter attach を呼ぶ際に
+# --dart-define-from-file を自動付与するインターセプター
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DART_DEFINES="$REPO_ROOT/.dart_defines"
+
+# PATH からこのスクリプト自身を除いた本物の flutter を探す
+REAL_FLUTTER=$(PATH="${PATH//$SCRIPT_DIR:/}" which flutter)
+
+if [[ "$1" == "attach" ]] && [ -f "$DART_DEFINES" ]; then
+  echo "[flutter wrapper] injecting --dart-define-from-file $DART_DEFINES" >&2
+  exec "$REAL_FLUTTER" "$@" --dart-define-from-file "$DART_DEFINES"
+else
+  exec "$REAL_FLUTTER" "$@"
+fi

--- a/scripts/mobai_install.sh
+++ b/scripts/mobai_install.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# mobai_install.sh
+# flutter run がカスタムデバイス向けに flutter_assets を渡してくる場合、
+# mobai ios_builder がビルドした dist/*.ipa を代わりにインストールする
+
+set -e
+
+LOCAL_PATH="$1"
+echo "[mobai_install] called with: $LOCAL_PATH" >&2
+
+BUILDER_URL="${MOBAI_URL:-http://YUZU-SURFACE.local:8686}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+if [[ "$LOCAL_PATH" == *"flutter_assets"* ]]; then
+  # flutter run (debug) は flutter_assets を渡してくるため、
+  # mobai ios_builder がビルドした dist/*.ipa を使用する
+  IPA_PATH=$(find "$REPO_ROOT/flutter_app/dist" -name "*.ipa" -type f 2>/dev/null | sort | tail -1)
+  if [ -z "$IPA_PATH" ]; then
+    echo "[mobai_install] Error: No IPA found in $REPO_ROOT/dist/" >&2
+    exit 1
+  fi
+  echo "[mobai_install] using IPA: $IPA_PATH" >&2
+else
+  IPA_PATH="$LOCAL_PATH"
+  echo "[mobai_install] using IPA: $IPA_PATH" >&2
+fi
+
+# MobAIサーバーはWindows上で動作するため、WSLパスをWindowsパスに変換する
+WIN_IPA_PATH=$(wslpath -w "$IPA_PATH")
+echo "[mobai_install] windows path: $WIN_IPA_PATH" >&2
+
+/usr/local/bin/builder mobai --url "$BUILDER_URL" install "$WIN_IPA_PATH"
+echo "[mobai_install] done" >&2


### PR DESCRIPTION
## Summary

- `scripts/flutter`: `flutter attach` 呼び出しに `--dart-define-from-file` を自動付与するラッパー
- `scripts/dev_flutter.sh`: `builder dev flutter` のラッパー（`scripts/flutter` を PATH に差し込む）
- `scripts/mobai_install.sh`: カスタムデバイスの install ハンドラー（`flutter_assets` を受け取ったとき `dist/*.ipa` を使用）

## 使い方

```bash
# sideloadly でインストール後、デバイスでアプリを起動してから
flutter run -d mobai-ios --dart-define-from-file ../.dart_defines
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)