### PR TITLE
ci: pushされたらiOSビルドを実行

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+      - 'feature/**'
+      - 'fix/**'
     paths:
       - 'flutter_app/**'
       - '.github/workflows/ios-build.yml'


### PR DESCRIPTION
## 概要
ブランチへのpush時に自動でiOSビルドを実行するCI設定を追加する。

## 変更内容
- `.github/workflows/ios-build.yml` に `push` トリガーを追加
  - `main` ブランチへの push 時に自動実行
  - `flutter_app/**` または `ios-build.yml` の変更時のみ起動（paths フィルター）
- `build_id` を `required: false` に変更し、未指定時は `github.sha` をフォールバックとして使用
- `ios_path` のデフォルト値を `flutter_app/ios` に設定

## Closes
Closes #25