### PR TITLE
release: v0.2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,137 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-ios:
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Create .dart_define
+        if: vars.DART_DEFINE_CONTENTS != ''
+        env:
+          DART_DEFINE_CONTENTS: ${{ vars.DART_DEFINE_CONTENTS }}
+        run: echo "$DART_DEFINE_CONTENTS" > .dart_defines
+
+      - name: Restore Pods cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            flutter_app/ios/Pods
+            ~/.cocoapods/repos
+          key: pods-${{ runner.os }}-${{ hashFiles('flutter_app/ios/Podfile.lock') }}
+          restore-keys: pods-${{ runner.os }}-
+
+      - name: Flutter pub get
+        run: flutter pub get
+        working-directory: flutter_app
+
+      - name: Build runner
+        run: dart run build_runner build --delete-conflicting-outputs
+        working-directory: flutter_app
+
+      - name: Build iOS (release, no codesign)
+        run: |
+          DART_DEFINE_ARGS=""
+          if [ -f "$GITHUB_WORKSPACE/.dart_defines" ]; then
+            DART_DEFINE_ARGS=$(python3 -c "import json; d=json.load(open('$GITHUB_WORKSPACE/.dart_defines')); print(' '.join(f'--dart-define={k}={v}' for k, v in d.items()))")
+          fi
+          flutter build ios --no-codesign --release $DART_DEFINE_ARGS
+        working-directory: flutter_app
+
+      - name: Create IPA
+        run: |
+          APP_PATH=$(find flutter_app/build/ios/iphoneos -name "*.app" -type d | head -1)
+          mkdir -p build/Payload
+          cp -R "$APP_PATH" build/Payload/
+          cd build
+          zip -rq "chitose_bus-${{ github.ref_name }}-ios.ipa" Payload
+          rm -rf Payload
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ios-ipa
+          path: build/chitose_bus-${{ github.ref_name }}-ios.ipa
+          if-no-files-found: error
+
+  build-android:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Create .dart_define
+        if: vars.DART_DEFINE_CONTENTS != ''
+        env:
+          DART_DEFINE_CONTENTS: ${{ vars.DART_DEFINE_CONTENTS }}
+        run: echo "$DART_DEFINE_CONTENTS" > .dart_defines
+
+      - name: Flutter pub get
+        run: flutter pub get
+        working-directory: flutter_app
+
+      - name: Build runner
+        run: dart run build_runner build --delete-conflicting-outputs
+        working-directory: flutter_app
+
+      - name: Build APK (release)
+        run: |
+          DART_DEFINE_ARGS=""
+          if [ -f "$GITHUB_WORKSPACE/.dart_defines" ]; then
+            DART_DEFINE_ARGS=$(python3 -c "import json; d=json.load(open('$GITHUB_WORKSPACE/.dart_defines')); print(' '.join(f'--dart-define={k}={v}' for k, v in d.items()))")
+          fi
+          flutter build apk --release $DART_DEFINE_ARGS
+        working-directory: flutter_app
+
+      - name: Rename APK
+        run: mv flutter_app/build/app/outputs/flutter-apk/app-release.apk chitose_bus-${{ github.ref_name }}-android.apk
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: android-apk
+          path: chitose_bus-${{ github.ref_name }}-android.apk
+          if-no-files-found: error
+
+  release:
+    needs: [build-ios, build-android]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: ios-ipa
+          path: artifacts/
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: android-apk
+          path: artifacts/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+          files: artifacts/*

--- a/flutter_app/pubspec.yaml
+++ b/flutter_app/pubspec.yaml
@@ -3,7 +3,7 @@ description: 千歳科学技術大学 シャトルバス時刻表アプリ
 
 publish_to: 'none'
 
-version: 0.1.1+3
+version: 0.2.0+4
 
 environment:
   sdk: '>=3.3.0 <4.0.0'


### PR DESCRIPTION
## Summary
- `pubspec.yaml` のバージョンを `0.1.1+3` → `0.2.0+4` に更新
- `release.yml` ワークフローを追加（`v*` タグ push 時に iOS IPA と Android APK をビルドして GitHub Release を自動作成）

## Test plan
- [ ] PR マージ後、`v0.2.0` タグを push する
- [ ] GitHub Actions の Release ワークフローが起動することを確認
- [ ] iOS (IPA) と Android (APK) のビルドが成功することを確認
- [ ] GitHub Release に両アーティファクトが添付されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)