### PR TITLE
fix: enable core library desugaring for Android release build

### DIFF
--- a/flutter_app/android/app/build.gradle.kts
+++ b/flutter_app/android/app/build.gradle.kts
@@ -11,6 +11,7 @@ android {
     ndkVersion = flutter.ndkVersion
 
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
@@ -41,4 +42,8 @@ android {
 
 flutter {
     source = "../.."
+}
+
+dependencies {
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.4")
 }


### PR DESCRIPTION
## Summary
- `flutter_local_notifications` が Android release ビルド時に core library desugaring を要求するため、有効化する

## Changes
- `build.gradle.kts`: `isCoreLibraryDesugaringEnabled = true` を追加
- `build.gradle.kts`: `desugar_jdk_libs:2.1.4` dependency を追加

## Test plan
- [ ] CI の `build-android` ジョブが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)