### PR TITLE
fix(notification): 設定変更時に通知が再スケジュールされない問題を修正

### DIFF
--- a/flutter_app/lib/presentation/viewmodels/notification_viewmodel.dart
+++ b/flutter_app/lib/presentation/viewmodels/notification_viewmodel.dart
@@ -57,13 +57,21 @@ class NotificationSettingsNotifier
       await service.cancelAll();
       return;
     }
-    await scheduleForTimetable(timetable);
+    await scheduleForTimetable(timetable, settingsOverride: settings);
   }
 
-  Future<void> scheduleForTimetable(BusTimetable timetable) async {
-    final settingsState = state;
-    if (settingsState is! AsyncData<NotificationSettings>) return;
-    final settings = settingsState.value;
+  /// [settingsOverride] が指定された場合はその設定を使用し、
+  /// 省略時は現在の [state] から設定を読み込む。
+  Future<void> scheduleForTimetable(BusTimetable timetable,
+      {NotificationSettings? settingsOverride}) async {
+    final NotificationSettings settings;
+    if (settingsOverride != null) {
+      settings = settingsOverride;
+    } else {
+      final settingsState = state;
+      if (settingsState is! AsyncData<NotificationSettings>) return;
+      settings = settingsState.value;
+    }
     if (!settings.enabled || settings.direction == null) return;
 
     final service = ref.read(notificationServiceProvider);

--- a/flutter_app/test/unit/presentation/notification_viewmodel_test.dart
+++ b/flutter_app/test/unit/presentation/notification_viewmodel_test.dart
@@ -279,6 +279,7 @@ void main() {
             .read(notificationSettingsProvider.notifier)
             .saveSettings(settings);
 
+        expect(service.scheduledCalls.length, greaterThan(0));
         expect(service.scheduledCalls.length, lessThanOrEqualTo(3));
       });
 


### PR DESCRIPTION
## Summary

- `saveSettings()` / `enableNotifications()` の後に `_rescheduleIfNeeded()` を呼び出し、設定変更と通知スケジュールを確実に連動させる
- timetable 未ロード時も `cancelAll()` を実行し、古い通知を残さないよう修正
- テスト 12 件を新規追加（`notification_viewmodel_test.dart`）

## Root Cause

`scheduleForTimetable()` は `home_screen.dart` でのデータ読み込み時にしか呼ばれておらず、通知設定画面で ON にしたり方面を変更しても通知が再スケジュールされなかった。

## Changes

### `notification_viewmodel.dart`
- `_rescheduleIfNeeded(settings)` を追加
  - `enabled=true` かつ `direction` 設定済み → 現在の時刻表で `scheduleForTimetable()` を呼ぶ
  - `enabled=false` または `direction=null` → `cancelAll()` のみ
  - timetable 未ロード → `cancelAll()` で古い通知をクリア
- `saveSettings()` の末尾で `_rescheduleIfNeeded()` を呼ぶ

### `test/unit/presentation/notification_viewmodel_test.dart`（新規）
| テストケース | 内容 |
|---|---|
| `saveSettings` enabled=true, direction 設定済み | 再スケジュールされる |
| `saveSettings` enabled=false | cancelAll のみ |
| `saveSettings` enabled=true, direction=null | cancelAll のみ |
| `saveSettings` minutesBefore 変更 | 新しい値で再スケジュール |
| `saveSettings` 最大3便 | 3件以下のみスケジュール |
| `saveSettings` 過去のバスのみ | scheduleNotification 呼ばれない |
| `saveSettings` timetable 未ロード | cancelAll が呼ばれる |
| `saveSettings` 方面違い混在 | 指定方面のみ通知 |
| `enableNotifications` 権限許可 | 再スケジュールされる |
| `enableNotifications` 権限拒否 | cancelAll のみ |
| `enableNotifications` 権限許可後 | enabled=true で保存 |
| `enableNotifications` 権限拒否後 | enabled=false で保存 |

## Test plan
- [ ] `flutter test` が全件通過することを確認
- [ ] iOS 実機で通知設定を ON にしたとき通知が届くことを確認
- [ ] 方面・minutesBefore を変更したとき新しい設定で通知が届くことを確認

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)