### PR TITLE
feat(notification): NotificationSettings に scheduledBusKeys を追加（PR-A）

### DIFF
--- a/flutter_app/lib/data/repositories/notification_settings_repository.dart
+++ b/flutter_app/lib/data/repositories/notification_settings_repository.dart
@@ -7,6 +7,7 @@ class NotificationSettingsRepository {
   static const _keyEnabled = 'notif_enabled';
   static const _keyMinutesBefore = 'notif_minutes_before';
   static const _keyDirection = 'notif_direction';
+  static const _keyScheduledBusKeys = 'notif_scheduled_bus_keys';
 
   Future<NotificationSettings> load() async {
     final prefs = await SharedPreferences.getInstance();
@@ -16,10 +17,13 @@ class NotificationSettingsRepository {
     final direction = directionIndex != null
         ? BusDirection.values[directionIndex]
         : null;
+    final scheduledBusKeys =
+        (prefs.getStringList(_keyScheduledBusKeys) ?? []).toSet();
     return NotificationSettings(
       enabled: enabled,
       minutesBefore: minutesBefore,
       direction: direction,
+      scheduledBusKeys: scheduledBusKeys,
     );
   }
 
@@ -32,5 +36,7 @@ class NotificationSettingsRepository {
     } else {
       await prefs.remove(_keyDirection);
     }
+    await prefs.setStringList(
+        _keyScheduledBusKeys, settings.scheduledBusKeys.toList());
   }
 }

--- a/flutter_app/lib/domain/entities/notification_settings.dart
+++ b/flutter_app/lib/domain/entities/notification_settings.dart
@@ -1,15 +1,17 @@
 import 'bus_schedule.dart';
 
 class NotificationSettings {
-  const NotificationSettings({
+  NotificationSettings({
     this.enabled = false,
     this.minutesBefore = 10,
     this.direction,
-  });
+    Set<String>? scheduledBusKeys,
+  }) : scheduledBusKeys = scheduledBusKeys ?? {};
 
   final bool enabled;
   final int minutesBefore;
   final BusDirection? direction;
+  final Set<String> scheduledBusKeys;
 
   static const minutesOptions = [5, 10, 15, 30];
 
@@ -18,11 +20,13 @@ class NotificationSettings {
     int? minutesBefore,
     BusDirection? direction,
     bool clearDirection = false,
+    Set<String>? scheduledBusKeys,
   }) {
     return NotificationSettings(
       enabled: enabled ?? this.enabled,
       minutesBefore: minutesBefore ?? this.minutesBefore,
       direction: clearDirection ? null : (direction ?? this.direction),
+      scheduledBusKeys: scheduledBusKeys ?? this.scheduledBusKeys,
     );
   }
 
@@ -32,8 +36,17 @@ class NotificationSettings {
       other is NotificationSettings &&
           enabled == other.enabled &&
           minutesBefore == other.minutesBefore &&
-          direction == other.direction;
+          direction == other.direction &&
+          _setEquals(scheduledBusKeys, other.scheduledBusKeys);
+
+  static bool _setEquals(Set<String> a, Set<String> b) =>
+      a.length == b.length && a.containsAll(b);
 
   @override
-  int get hashCode => Object.hash(enabled, minutesBefore, direction);
+  int get hashCode => Object.hash(
+        enabled,
+        minutesBefore,
+        direction,
+        Object.hashAllUnordered(scheduledBusKeys),
+      );
 }

--- a/flutter_app/lib/domain/entities/notification_settings.dart
+++ b/flutter_app/lib/domain/entities/notification_settings.dart
@@ -6,7 +6,7 @@ class NotificationSettings {
     this.minutesBefore = 10,
     this.direction,
     Set<String>? scheduledBusKeys,
-  }) : scheduledBusKeys = scheduledBusKeys ?? {};
+  }) : scheduledBusKeys = Set.unmodifiable(scheduledBusKeys ?? {});
 
   final bool enabled;
   final int minutesBefore;

--- a/flutter_app/test/unit/data/notification_settings_repository_test.dart
+++ b/flutter_app/test/unit/data/notification_settings_repository_test.dart
@@ -20,7 +20,7 @@ void main() {
 
     test('save して load: 値が永続化される', () async {
       final repo = NotificationSettingsRepository();
-      const saved = NotificationSettings(
+      final saved = NotificationSettings(
         enabled: true,
         minutesBefore: 5,
         direction: BusDirection.fromChitose,
@@ -33,15 +33,39 @@ void main() {
     test('direction=null で save して load: direction が null', () async {
       final repo = NotificationSettingsRepository();
       // まず direction あり で保存
-      await repo.save(const NotificationSettings(
+      await repo.save(NotificationSettings(
         enabled: true,
         minutesBefore: 10,
         direction: BusDirection.fromHonbuto,
       ));
       // direction なし で上書き
-      await repo.save(const NotificationSettings(enabled: false));
+      await repo.save(NotificationSettings(enabled: false));
       final loaded = await repo.load();
       expect(loaded.direction, isNull);
+    });
+
+    test('scheduledBusKeys: save して load: キーが永続化される', () async {
+      final repo = NotificationSettingsRepository();
+      final saved = NotificationSettings(
+        enabled: true,
+        minutesBefore: 10,
+        scheduledBusKeys: {'fromChitose_08:30', 'toChitose_09:00'},
+      );
+      await repo.save(saved);
+      final loaded = await repo.load();
+      expect(loaded.scheduledBusKeys, {'fromChitose_08:30', 'toChitose_09:00'});
+    });
+
+    test('scheduledBusKeys: 空で save して load: 空の Set', () async {
+      final repo = NotificationSettingsRepository();
+      // まずキーあり で保存
+      await repo.save(NotificationSettings(
+        scheduledBusKeys: {'fromChitose_08:30'},
+      ));
+      // 空で上書き
+      await repo.save(NotificationSettings());
+      final loaded = await repo.load();
+      expect(loaded.scheduledBusKeys, isEmpty);
     });
   });
 }

--- a/flutter_app/test/unit/domain/notification_settings_test.dart
+++ b/flutter_app/test/unit/domain/notification_settings_test.dart
@@ -5,14 +5,14 @@ import 'package:chitose_bus/domain/entities/notification_settings.dart';
 void main() {
   group('NotificationSettings', () {
     test('デフォルト値: enabled=false, minutesBefore=10, direction=null', () {
-      const s = NotificationSettings();
+      final s = NotificationSettings();
       expect(s.enabled, isFalse);
       expect(s.minutesBefore, 10);
       expect(s.direction, isNull);
     });
 
     test('copyWith: enabled のみ変更', () {
-      const s = NotificationSettings();
+      final s = NotificationSettings();
       final s2 = s.copyWith(enabled: true);
       expect(s2.enabled, isTrue);
       expect(s2.minutesBefore, 10);
@@ -20,20 +20,20 @@ void main() {
     });
 
     test('copyWith: minutesBefore のみ変更', () {
-      const s = NotificationSettings(enabled: true, minutesBefore: 10);
+      final s = NotificationSettings(enabled: true, minutesBefore: 10);
       final s2 = s.copyWith(minutesBefore: 5);
       expect(s2.minutesBefore, 5);
       expect(s2.enabled, isTrue);
     });
 
     test('copyWith: direction を設定', () {
-      const s = NotificationSettings();
+      final s = NotificationSettings();
       final s2 = s.copyWith(direction: BusDirection.fromChitose);
       expect(s2.direction, BusDirection.fromChitose);
     });
 
     test('copyWith: clearDirection=true で direction を null に', () {
-      const s = NotificationSettings(direction: BusDirection.fromChitose);
+      final s = NotificationSettings(direction: BusDirection.fromChitose);
       final s2 = s.copyWith(clearDirection: true);
       expect(s2.direction, isNull);
     });
@@ -43,10 +43,44 @@ void main() {
     });
 
     test('== と hashCode: 同じ値は等しい', () {
-      const a = NotificationSettings(enabled: true, minutesBefore: 5, direction: BusDirection.fromChitose);
-      const b = NotificationSettings(enabled: true, minutesBefore: 5, direction: BusDirection.fromChitose);
+      final a = NotificationSettings(enabled: true, minutesBefore: 5, direction: BusDirection.fromChitose);
+      final b = NotificationSettings(enabled: true, minutesBefore: 5, direction: BusDirection.fromChitose);
       expect(a, equals(b));
       expect(a.hashCode, equals(b.hashCode));
+    });
+
+    group('scheduledBusKeys', () {
+      test('デフォルト値は空の Set', () {
+        final s = NotificationSettings();
+        expect(s.scheduledBusKeys, isEmpty);
+      });
+
+      test('copyWith: scheduledBusKeys を設定', () {
+        final s = NotificationSettings();
+        final s2 = s.copyWith(scheduledBusKeys: {'fromChitose_08:30', 'toChitose_09:00'});
+        expect(s2.scheduledBusKeys, {'fromChitose_08:30', 'toChitose_09:00'});
+        expect(s2.enabled, isFalse);
+        expect(s2.minutesBefore, 10);
+      });
+
+      test('copyWith: scheduledBusKeys を省略すると元の値を保持', () {
+        final s = NotificationSettings(scheduledBusKeys: {'fromChitose_08:30'});
+        final s2 = s.copyWith(enabled: true);
+        expect(s2.scheduledBusKeys, {'fromChitose_08:30'});
+      });
+
+      test('== と hashCode: scheduledBusKeys が等しければ等しい', () {
+        final a = NotificationSettings(scheduledBusKeys: {'fromChitose_08:30'});
+        final b = NotificationSettings(scheduledBusKeys: {'fromChitose_08:30'});
+        expect(a, equals(b));
+        expect(a.hashCode, equals(b.hashCode));
+      });
+
+      test('== : scheduledBusKeys が異なれば不等', () {
+        final a = NotificationSettings(scheduledBusKeys: {'fromChitose_08:30'});
+        final b = NotificationSettings(scheduledBusKeys: {'toChitose_09:00'});
+        expect(a, isNot(equals(b)));
+      });
     });
   });
 }

--- a/flutter_app/test/unit/domain/notification_settings_test.dart
+++ b/flutter_app/test/unit/domain/notification_settings_test.dart
@@ -81,6 +81,11 @@ void main() {
         final b = NotificationSettings(scheduledBusKeys: {'toChitose_09:00'});
         expect(a, isNot(equals(b)));
       });
+
+      test('scheduledBusKeys は immutable（外部からの変更が例外を投げる）', () {
+        final s = NotificationSettings(scheduledBusKeys: {'fromChitose_08:30'});
+        expect(() => s.scheduledBusKeys.add('toChitose_09:00'), throwsUnsupportedError);
+      });
     });
   });
 }

--- a/flutter_app/test/unit/presentation/notification_viewmodel_test.dart
+++ b/flutter_app/test/unit/presentation/notification_viewmodel_test.dart
@@ -40,7 +40,7 @@ class FakeNotificationSettingsRepository
   NotificationSettings _stored;
 
   FakeNotificationSettingsRepository([NotificationSettings? initial])
-      : _stored = initial ?? const NotificationSettings();
+      : _stored = initial ?? NotificationSettings();
 
   @override
   Future<NotificationSettings> load() async => _stored;
@@ -187,7 +187,7 @@ void main() {
         addTearDown(container.dispose);
         await awaitProviders(container);
 
-        const settings = NotificationSettings(
+        final settings = NotificationSettings(
           enabled: true,
           minutesBefore: 10,
           direction: BusDirection.fromChitose,
@@ -208,7 +208,7 @@ void main() {
         addTearDown(container.dispose);
         await awaitProviders(container);
 
-        const settings = NotificationSettings(enabled: false);
+        final settings = NotificationSettings(enabled: false);
         await container
             .read(notificationSettingsProvider.notifier)
             .saveSettings(settings);
@@ -225,7 +225,7 @@ void main() {
         addTearDown(container.dispose);
         await awaitProviders(container);
 
-        const settings = NotificationSettings(
+        final settings = NotificationSettings(
           enabled: true,
           minutesBefore: 10,
           // direction: null
@@ -245,7 +245,7 @@ void main() {
         addTearDown(container.dispose);
         await awaitProviders(container);
 
-        const settings = NotificationSettings(
+        final settings = NotificationSettings(
           enabled: true,
           minutesBefore: 5,
           direction: BusDirection.fromChitose,
@@ -270,7 +270,7 @@ void main() {
         addTearDown(container.dispose);
         await awaitProviders(container);
 
-        const settings = NotificationSettings(
+        final settings = NotificationSettings(
           enabled: true,
           minutesBefore: 10,
           direction: BusDirection.fromChitose,
@@ -292,7 +292,7 @@ void main() {
         addTearDown(container.dispose);
         await awaitProviders(container);
 
-        const settings = NotificationSettings(
+        final settings = NotificationSettings(
           enabled: true,
           minutesBefore: 10,
           direction: BusDirection.fromChitose,
@@ -321,7 +321,7 @@ void main() {
         // notificationSettingsProvider だけ初期化を待つ
         await container.read(notificationSettingsProvider.future);
 
-        const settings = NotificationSettings(
+        final settings = NotificationSettings(
           enabled: true,
           minutesBefore: 10,
           direction: BusDirection.fromChitose,
@@ -344,7 +344,7 @@ void main() {
         addTearDown(container.dispose);
         await awaitProviders(container);
 
-        const settings = NotificationSettings(
+        final settings = NotificationSettings(
           enabled: true,
           minutesBefore: 10,
           direction: BusDirection.fromChitose,
@@ -366,7 +366,7 @@ void main() {
         final service = FakeNotificationService(permissionGranted: true);
         final container = makeContainer(
           service: service,
-          initialSettings: const NotificationSettings(
+          initialSettings: NotificationSettings(
             enabled: false,
             minutesBefore: 10,
             direction: BusDirection.fromChitose,
@@ -389,7 +389,7 @@ void main() {
         final service = FakeNotificationService(permissionGranted: false);
         final container = makeContainer(
           service: service,
-          initialSettings: const NotificationSettings(
+          initialSettings: NotificationSettings(
             enabled: false,
             minutesBefore: 10,
             direction: BusDirection.fromChitose,
@@ -413,7 +413,7 @@ void main() {
         final service = FakeNotificationService(permissionGranted: true);
         final container = makeContainer(
           service: service,
-          initialSettings: const NotificationSettings(
+          initialSettings: NotificationSettings(
             enabled: false,
             direction: BusDirection.fromChitose,
           ),
@@ -435,7 +435,7 @@ void main() {
         final service = FakeNotificationService(permissionGranted: false);
         final container = makeContainer(
           service: service,
-          initialSettings: const NotificationSettings(
+          initialSettings: NotificationSettings(
             enabled: false,
             direction: BusDirection.fromChitose,
           ),

--- a/flutter_app/test/widget/notification_settings_screen_test.dart
+++ b/flutter_app/test/widget/notification_settings_screen_test.dart
@@ -32,7 +32,7 @@ Widget _wrap(NotificationSettings settings) => ProviderScope(
 void main() {
   group('NotificationSettingsScreen', () {
     testWidgets('初期表示: スイッチ・通知タイミング・路線ラベルが表示される', (tester) async {
-      await tester.pumpWidget(_wrap(const NotificationSettings()));
+      await tester.pumpWidget(_wrap(NotificationSettings()));
       await tester.pump();
 
       expect(find.text('出発通知を有効にする'), findsOneWidget);
@@ -41,7 +41,7 @@ void main() {
     });
 
     testWidgets('enabled=false: ドロップダウンが無効状態', (tester) async {
-      await tester.pumpWidget(_wrap(const NotificationSettings(enabled: false)));
+      await tester.pumpWidget(_wrap(NotificationSettings(enabled: false)));
       await tester.pump();
 
       // DropdownButton が disabled (onChanged == null) の場合、opacity が下がる
@@ -51,14 +51,14 @@ void main() {
 
     testWidgets('enabled=true かつ direction=null: 警告テキストが表示される', (tester) async {
       await tester.pumpWidget(
-          _wrap(const NotificationSettings(enabled: true)));
+          _wrap(NotificationSettings(enabled: true)));
       await tester.pump();
 
       expect(find.text('通知を受け取るには路線を選択してください'), findsOneWidget);
     });
 
     testWidgets('enabled=true かつ direction 設定済み: 警告テキストが非表示', (tester) async {
-      await tester.pumpWidget(_wrap(const NotificationSettings(
+      await tester.pumpWidget(_wrap(NotificationSettings(
         enabled: true,
         direction: BusDirection.fromChitose,
       )));


### PR DESCRIPTION
## 概要

Issue #42 の Strangler Fig 実装 PR-A。既存の `direction` フィールドを保持しながら、新しい `scheduledBusKeys: Set<String>` フィールドをデータ層に追加する。

## 変更内容

- `NotificationSettings` に `scheduledBusKeys: Set<String>` を追加（デフォルト空）
- `copyWith()` / `==` / `hashCode` を `scheduledBusKeys` 対応に更新
- `NotificationSettingsRepository` に `notif_scheduled_bus_keys` キーでの save/load を追加

## 方針

- **additive のみ**: `direction` 関連コードはすべて保持
- テストは全108件パス

## Strangler Fig フェーズ

| PR | 内容 | ステータス |
|---|---|---|
| **PR-A（本PR）** | データ層: `scheduledBusKeys` 追加 | ✅ |
| PR-B | サービス層: `cancel(int id)` 追加 | 未 |
| PR-C | ViewModel: `toggleBusNotification` 追加 | 未 |
| PR-D | UI: ベルアイコン追加 | 未 |
| PR-E | 旧機能除去 | 未 |

Closes #42 (partial)