### PR TITLE
fix: TestFlight アップロードの IPA パスをグロブから実パスに変更 (#87)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,12 +120,15 @@ jobs:
             -archivePath "$GITHUB_WORKSPACE/build/Runner.xcarchive" \
             -exportOptionsPlist ios/ExportOptions.plist \
             -exportPath "$GITHUB_WORKSPACE/build/ios/ipa"
+
+          IPA_PATH=$(find "$GITHUB_WORKSPACE/build/ios/ipa" -name "*.ipa" | head -1)
+          echo "IPA_PATH=$IPA_PATH" >> $GITHUB_ENV
         working-directory: flutter_app
 
       - name: Upload to TestFlight
         uses: apple-actions/upload-testflight-build@v3
         with:
-          app-path: build/ios/ipa/*.ipa
+          app-path: ${{ env.IPA_PATH }}
           issuer-id: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
           api-key-id: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           api-private-key: ${{ secrets.APP_STORE_CONNECT_API_PRIVATE_KEY }}


### PR DESCRIPTION
## 概要

- ビルドステップ末尾で `find` により IPA の実パスを取得し `$GITHUB_ENV` に保存
- Upload to TestFlight ステップで `${{ env.IPA_PATH }}` を使用するよう変更

closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)