### PR TITLE
chore: ビルド番号を +9 にバンプ (0.6.1+9)

### DIFF
--- a/flutter_app/pubspec.yaml
+++ b/flutter_app/pubspec.yaml
@@ -20,7 +20,7 @@ flutter_launcher_icons:
 
 publish_to: 'none'
 
-version: 0.6.1+8
+version: 0.6.1+9
 
 environment:
   sdk: '>=3.3.0 <4.0.0'


### PR DESCRIPTION
## 概要

- ビルド番号を +8 → +9 に変更
- TestFlight アップロード時のビルド番号重複エラー (-19241) の解消

🤖 Generated with [Claude Code](https://claude.com/claude-code)