### PR TITLE
fix: GitHub username 変更に伴う URL を myu-mikazuki に更新 (#105)

### DIFF
--- a/docs/privacy_policy.html
+++ b/docs/privacy_policy.html
@@ -46,7 +46,7 @@
 
   <h2>5. お問い合わせ</h2>
   <p>本ポリシーに関するご質問は、以下の GitHub Issues よりお問い合わせください。</p>
-  <p><a href="https://github.com/Yuzucchi-cist/Chitose-bus/issues">https://github.com/Yuzucchi-cist/Chitose-bus/issues</a></p>
+  <p><a href="https://github.com/myu-mikazuki/Chitose-bus/issues">https://github.com/myu-mikazuki/Chitose-bus/issues</a></p>
 </div>
 
 <hr class="divider">
@@ -74,7 +74,7 @@
 
   <h2>5. Contact</h2>
   <p>If you have any questions about this policy, please contact us via GitHub Issues:</p>
-  <p><a href="https://github.com/Yuzucchi-cist/Chitose-bus/issues">https://github.com/Yuzucchi-cist/Chitose-bus/issues</a></p>
+  <p><a href="https://github.com/myu-mikazuki/Chitose-bus/issues">https://github.com/myu-mikazuki/Chitose-bus/issues</a></p>
 </div>
 
 </body>

--- a/flutter_app/builder.json
+++ b/flutter_app/builder.json
@@ -2,7 +2,7 @@
   "project": "ios",
   "platform": "ios",
   "github": {
-    "owner": "Yuzucchi-cist",
+    "owner": "myu-mikazuki",
     "repo": "Chitose-bus"
   },
   "ios": {

--- a/flutter_app/lib/core/constants/app_constants.dart
+++ b/flutter_app/lib/core/constants/app_constants.dart
@@ -16,7 +16,7 @@ class AppConstants {
 
   /// プライバシーポリシーの公開URL
   static const String privacyPolicyUrl =
-      'https://yuzucchi-cist.github.io/Chitose-bus/privacy_policy.html';
+      'https://myu-mikazuki.github.io/Chitose-bus/privacy_policy.html';
 
   /// AdMob バナー広告ユニット ID (Android)
   /// --dart-define=ADMOB_ANDROID_AD_UNIT_ID=ca-app-pub-xxx/xxx で渡す


### PR DESCRIPTION
## 概要

GitHub username を `Yuzucchi-cist` から `myu-mikazuki` へ変更したことに伴い、旧 username を参照していた URL を修正します。

closes #105

## 変更内容

- `flutter_app/lib/core/constants/app_constants.dart` — `privacyPolicyUrl` を `myu-mikazuki.github.io` に更新
- `flutter_app/builder.json` — `owner` を `myu-mikazuki` に更新
- `docs/privacy_policy.html` — お問い合わせ先リンクを `github.com/myu-mikazuki` に更新

## 補足

- `README.md` の過去リリースリンクは GitHub のリダイレクトが有効な間は動作するため、今回は対象外とした
- マージ後は `develop` へのマージバックを実施すること