### PR TITLE
chore: バージョンを v0.7.2+12 にバンプ

### DIFF
--- a/flutter_app/pubspec.yaml
+++ b/flutter_app/pubspec.yaml
@@ -20,7 +20,7 @@ flutter_launcher_icons:
 
 publish_to: 'none'
 
-version: 0.7.1+11
+version: 0.7.2+12
 
 environment:
   sdk: '>=3.3.0 <4.0.0'


### PR DESCRIPTION
hotfix #105 のマージ後にバージョンバンプが漏れていたため、別途対応します。

- `pubspec.yaml`: `0.7.1+11` → `0.7.2+12`

マージ後に `v0.7.2` タグを本コミットに移動します。