### PR TITLE
release: v1.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,9 +104,9 @@ jobs:
             sed -i '' "s|ADMOB_APP_ID = .*|ADMOB_APP_ID = $ADMOB_IOS_APP_ID|" ios/Flutter/Release.xcconfig
           fi
 
-          DART_DEFINE_ARGS=""
+          DART_DEFINE_ARGS="--dart-define=USE_TEST_ADS=false"
           if [ -f "$GITHUB_WORKSPACE/.dart_defines" ]; then
-            DART_DEFINE_ARGS=$(python3 -c "import json; d=json.load(open('$GITHUB_WORKSPACE/.dart_defines')); print(' '.join(f'--dart-define={k}={v}' for k, v in d.items()))")
+            DART_DEFINE_ARGS="$DART_DEFINE_ARGS $(python3 -c "import json; d=json.load(open('$GITHUB_WORKSPACE/.dart_defines')); print(' '.join(f'--dart-define={k}={v}' for k, v in d.items()))")"
           fi
 
           flutter build ios --release --no-codesign $DART_DEFINE_ARGS
@@ -184,10 +184,9 @@ jobs:
 
       - name: Set DART_DEFINE_ARGS
         run: |
+          DART_DEFINE_ARGS="--dart-define=USE_TEST_ADS=false"
           if [ -f "$GITHUB_WORKSPACE/.dart_defines" ]; then
-            DART_DEFINE_ARGS=$(python3 -c "import json; d=json.load(open('$GITHUB_WORKSPACE/.dart_defines')); print(' '.join(f'--dart-define={k}={v}' for k, v in d.items()))")
-          else
-            DART_DEFINE_ARGS=""
+            DART_DEFINE_ARGS="$DART_DEFINE_ARGS $(python3 -c "import json; d=json.load(open('$GITHUB_WORKSPACE/.dart_defines')); print(' '.join(f'--dart-define={k}={v}' for k, v in d.items()))")"
           fi
           echo "DART_DEFINE_ARGS=$DART_DEFINE_ARGS" >> $GITHUB_ENV
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,9 @@ jobs:
           channel: stable
           cache: true
 
+      - name: Disable Swift Package Manager
+        run: flutter config --no-enable-swift-package-manager
+
       - name: Create .dart_define
         if: vars.DART_DEFINE_CONTENTS != ''
         env:
@@ -161,6 +164,9 @@ jobs:
         with:
           channel: stable
           cache: true
+
+      - name: Disable Swift Package Manager
+        run: flutter config --no-enable-swift-package-manager
 
       - name: Create .dart_define
         if: vars.DART_DEFINE_CONTENTS != ''

--- a/flutter_app/android/app/build.gradle.kts
+++ b/flutter_app/android/app/build.gradle.kts
@@ -45,7 +45,8 @@ android {
 
     buildTypes {
         debug {
-            manifestPlaceholders["admobAppId"] = "ca-app-pub-3940256099942544~3347511713"
+            manifestPlaceholders["admobAppId"] = System.getenv("ADMOB_ANDROID_APP_ID")
+                ?: "ca-app-pub-3940256099942544~3347511713"
         }
         release {
             manifestPlaceholders["admobAppId"] = System.getenv("ADMOB_ANDROID_APP_ID")

--- a/flutter_app/ios/.gitignore
+++ b/flutter_app/ios/.gitignore
@@ -19,6 +19,7 @@ Flutter/App.framework
 Flutter/Flutter.framework
 Flutter/Flutter.podspec
 Flutter/Generated.xcconfig
+Flutter/Local.xcconfig
 Flutter/ephemeral/
 Flutter/app.flx
 Flutter/app.zip

--- a/flutter_app/ios/Flutter/Debug.xcconfig
+++ b/flutter_app/ios/Flutter/Debug.xcconfig
@@ -1,2 +1,3 @@
 #include "Generated.xcconfig"
+#include? "Local.xcconfig"
 ADMOB_APP_ID = ca-app-pub-3940256099942544~1458002511

--- a/flutter_app/lib/core/constants/app_constants.dart
+++ b/flutter_app/lib/core/constants/app_constants.dart
@@ -18,19 +18,22 @@ class AppConstants {
   static const String privacyPolicyUrl =
       'https://myu-mikazuki.github.io/Chitose-bus/privacy_policy.html';
 
-  /// AdMob バナー広告ユニット ID (Android)
-  /// --dart-define=ADMOB_ANDROID_AD_UNIT_ID=ca-app-pub-xxx/xxx で渡す
-  /// デフォルトはテスト用ID
-  static const String admobAndroidAdUnitId = String.fromEnvironment(
-    'ADMOB_ANDROID_AD_UNIT_ID',
-    defaultValue: 'ca-app-pub-3940256099942544/6300978111',
+  /// false を渡すと本番の広告ユニット ID を使用する（CI リリースビルド用）
+  /// デフォルトは true（テスト用 ID）
+  static const bool _useTestAds = bool.fromEnvironment(
+    'USE_TEST_ADS',
+    defaultValue: true,
   );
 
+  /// AdMob バナー広告ユニット ID (Android)
+  /// 本番: --dart-define=USE_TEST_ADS=false --dart-define=ADMOB_ANDROID_AD_UNIT_ID=ca-app-pub-xxx/xxx
+  static const String admobAndroidAdUnitId = _useTestAds
+      ? 'ca-app-pub-3940256099942544/6300978111'
+      : String.fromEnvironment('ADMOB_ANDROID_AD_UNIT_ID');
+
   /// AdMob バナー広告ユニット ID (iOS)
-  /// --dart-define=ADMOB_IOS_AD_UNIT_ID=ca-app-pub-xxx/xxx で渡す
-  /// デフォルトはテスト用ID
-  static const String admobIosAdUnitId = String.fromEnvironment(
-    'ADMOB_IOS_AD_UNIT_ID',
-    defaultValue: 'ca-app-pub-3940256099942544/2934735716',
-  );
+  /// 本番: --dart-define=USE_TEST_ADS=false --dart-define=ADMOB_IOS_AD_UNIT_ID=ca-app-pub-xxx/xxx
+  static const String admobIosAdUnitId = _useTestAds
+      ? 'ca-app-pub-3940256099942544/2934735716'
+      : String.fromEnvironment('ADMOB_IOS_AD_UNIT_ID');
 }

--- a/flutter_app/pubspec.yaml
+++ b/flutter_app/pubspec.yaml
@@ -20,7 +20,7 @@ flutter_launcher_icons:
 
 publish_to: 'none'
 
-version: 0.8.3+17
+version: 1.0.0+18
 
 environment:
   sdk: '>=3.3.0 <4.0.0'


### PR DESCRIPTION
## Summary

- バージョンを \`0.8.3+17\` → \`1.0.0+18\` にバンプ
- \`USE_TEST_ADS\` dart-define で AdMob 広告ユニット ID の test/prod 切り替えを実装
- \`release.yml\` でリリースビルド時に \`USE_TEST_ADS=false\` を明示的に渡すよう変更
- Android debug ビルドで \`ADMOB_ANDROID_APP_ID\` 環境変数から App ID を取得可能に
- iOS \`Debug.xcconfig\` に \`Local.xcconfig\` のインクルードを追加（ローカルで本番 ID に切り替える際に使用）

## マージ方法

⚠️ このブランチは release ブランチです。**マージコミット（squash ではなく）** でマージしてください。

## リリース後の作業

1. \`main\` にマージ後、\`v1.0.0\` タグを打つ
2. CI が自動で TestFlight アップロード + APK/AAB ビルドを実行
3. App Store Connect で審査提出
4. Google Play Console で本番トラックに AAB をアップロード

🤖 Generated with [Claude Code](https://claude.com/claude-code)