### PR TITLE
chore: app-ads.txt を追加して AdMob 広告配信を認証する

### DIFF
--- a/docs/app-ads.txt
+++ b/docs/app-ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-9024018858456382, DIRECT, f08c47fec0942fa0

--- a/docs/app-ads.txt
+++ b/docs/app-ads.txt
@@ -1,1 +1,2 @@
 google.com, pub-9024018858456382, DIRECT, f08c47fec0942fa0
+google.com, pub-9024018858456382, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
`docs/app-ads.txt` を追加し、AdMob ( pub-9024018858456382) による広告配信の認証を追加