### PR TITLE
refactor: BusDirection を廃止し乗車地で便を引くようにする

### DIFF
--- a/flutter_app/integration_test/app_test.dart
+++ b/flutter_app/integration_test/app_test.dart
@@ -19,53 +19,53 @@ final _mockResponse = ScheduleResponse(
     schedules: [
       BusEntry(
         time: '09:00',
-        direction: BusDirection.fromChitose,
-        destination: '千歳科技大',
+        boardingStopId: 'chitose',
+        destination: '科技大',
         arrivals: {'kenkyuto': '09:20', 'honbuto': '09:25'},
       ),
       BusEntry(
         time: '23:59',
-        direction: BusDirection.fromChitose,
-        destination: '千歳科技大',
+        boardingStopId: 'chitose',
+        destination: '科技大',
       ),
       BusEntry(
         time: '09:30',
-        direction: BusDirection.fromMinamiChitose,
-        destination: '千歳科技大',
+        boardingStopId: 'minamiChitose',
+        destination: '科技大',
       ),
       BusEntry(
         time: '23:59',
-        direction: BusDirection.fromMinamiChitose,
-        destination: '千歳科技大',
+        boardingStopId: 'minamiChitose',
+        destination: '科技大',
       ),
       BusEntry(
         time: '10:00',
-        direction: BusDirection.fromKenkyutoToHonbuto,
+        boardingStopId: 'kenkyuto',
         destination: '本部棟',
       ),
       BusEntry(
         time: '23:59',
-        direction: BusDirection.fromKenkyutoToHonbuto,
+        boardingStopId: 'kenkyuto',
         destination: '本部棟',
       ),
       BusEntry(
         time: '10:30',
-        direction: BusDirection.fromKenkyutoToStation,
+        boardingStopId: 'kenkyuto',
         destination: '千歳駅',
       ),
       BusEntry(
         time: '23:59',
-        direction: BusDirection.fromKenkyutoToStation,
+        boardingStopId: 'kenkyuto',
         destination: '千歳駅',
       ),
       BusEntry(
         time: '11:00',
-        direction: BusDirection.fromHonbuto,
+        boardingStopId: 'honbuto',
         destination: '千歳駅',
       ),
       BusEntry(
         time: '23:59',
-        direction: BusDirection.fromHonbuto,
+        boardingStopId: 'honbuto',
         destination: '千歳駅',
       ),
     ],
@@ -76,8 +76,8 @@ final _mockResponse = ScheduleResponse(
     schedules: [
       BusEntry(
         time: '09:00',
-        direction: BusDirection.fromChitose,
-        destination: '千歳科技大',
+        boardingStopId: 'chitose',
+        destination: '科技大',
       ),
     ],
   ),

--- a/flutter_app/lib/data/models/bus_schedule_model.dart
+++ b/flutter_app/lib/data/models/bus_schedule_model.dart
@@ -43,6 +43,9 @@ class StopModel with _$StopModel {
     required String id,
     required String label,
 
+    /// タブなど幅の狭い場所で使う短縮名。正式名と同じなら GAS は返さない
+    String? shortLabel,
+
     /// 乗車地として選べるか。GAS は false のときだけ返す
     @Default(true) bool boardable,
   }) = _StopModel;
@@ -77,66 +80,34 @@ class ScheduleResponseModel with _$ScheduleResponseModel {
       _$ScheduleResponseModelFromJson(json);
 }
 
-// ---- 旧形式（BusDirection ごとの1件）への展開 ----
+// ---- 乗車地ごとの BusEntry への展開 ----
 //
-// GAS の応答は1便を1件だが、アプリの画面はまだ「乗車地ごとの1件」を前提に
-// できている。表示を変えずにデータ層だけ差し替えるため、ここで展開して
-// 従来と同じ BusEntry の並びを作る。
+// GAS の応答は1便を1件だが、画面は「この停留所から乗るとどうなるか」を出すため、
+// 便が通る停留所それぞれについて BusEntry を作る。
 //
-// **この展開は乗車地選択の UI を入れる際に削除する。** 画面が停留所の並びを
-// 直接扱えるようになれば、BusDirection ごと不要になる。
-
-/// 旧形式で乗車地として出す停留所と、対応する BusDirection。
-/// GAS 側の LEGACY_BOARDING と同じ内容（片方だけ変えると表示が食い違う）。
-///
-/// GAS 側は ROUTES の direction をキーにしているが、v=4 の応答は direction を
-/// 持たないため、ここでは destination で引くしかない。表示用の文字列に依存する
-/// 弱い作りなので、解決できなければ**黙って捨てずに落とす**（下記参照）。
-/// scripts/check_gas_response.js が GAS 側の destination の集合を検査している。
-const _legacyBoarding = <String, List<(String, BusDirection)>>{
-  '科技大': [
-    ('chitose', BusDirection.fromChitose),
-    ('minamiChitose', BusDirection.fromMinamiChitose),
-    ('kenkyuto', BusDirection.fromKenkyutoToHonbuto),
-  ],
-  '千歳駅': [
-    ('honbuto', BusDirection.fromHonbuto),
-    ('kenkyuto', BusDirection.fromKenkyutoToStation),
-  ],
-};
-
-/// 旧形式が扱える4停留所。arrivals はこれだけに絞る
-const _legacyStops = {'chitose', 'minamiChitose', 'kenkyuto', 'honbuto'};
+// 展開の大きさは選んだ停留所の数で決まる（既定の4停留所なら1便あたり3件）。
+// GAS が選択で絞ってくれるので、ここが膨らむことはない。
 
 extension TripModelMapper on TripModel {
-  /// 乗車地ごとの BusEntry に展開する（通らない乗車地は作らない）
+  /// 便が通る各停留所について、そこから乗る場合の BusEntry を作る。
+  /// 後に停留所が無い（＝終点）ものは乗車地にならないので作らない。
   List<BusEntry> toEntries() {
-    final boarding = _legacyBoarding[destination];
-    // 空を返すと、その系統の便がエラーも出さず全部消えて「バスがありません」に
-    // なる。時刻表アプリでは黙って消えるのが一番まずいので、見えるように落とす。
-    if (boarding == null) {
-      throw FormatException('未知の行き先です: $destination');
-    }
-
     final out = <BusEntry>[];
-    for (final (stopId, direction) in boarding) {
-      final index = stops.indexWhere((s) => s.id == stopId);
-      if (index < 0) continue;
-
-      // 乗車地より後にある停留所のうち、旧形式が扱える4つだけを到着として持つ
+    for (var i = 0; i < stops.length; i++) {
       final arrivals = <String, String>{};
-      for (final s in stops.skip(index + 1)) {
-        if (_legacyStops.contains(s.id)) arrivals[s.id] = s.time;
+      // 通過順のまま入れる。表示順はこの順序に従う
+      for (final s in stops.skip(i + 1)) {
+        arrivals[s.id] = s.time;
       }
       if (arrivals.isEmpty) continue;
 
       out.add(BusEntry(
-        time: stops[index].time,
-        direction: direction,
+        time: stops[i].time,
+        boardingStopId: stops[i].id,
         destination: destination,
         arrivals: arrivals,
         routeLabel: routeLabel,
-        platformNumber: stops[index].platform,
+        platformNumber: stops[i].platform,
         weekdayOnly: weekdayOnly,
         weekendOnly: weekendOnly,
         academicOnly: academicOnly,
@@ -148,8 +119,12 @@ extension TripModelMapper on TripModel {
 }
 
 extension StopModelMapper on StopModel {
-  BusStop toEntity() =>
-      BusStop(id: id, label: label, boardable: boardable);
+  BusStop toEntity() => BusStop(
+        id: id,
+        label: label,
+        shortLabel: shortLabel,
+        boardable: boardable,
+      );
 }
 
 extension BusTimetableModelMapper on BusTimetableModel {

--- a/flutter_app/lib/data/repositories/schedule_repository_impl.dart
+++ b/flutter_app/lib/data/repositories/schedule_repository_impl.dart
@@ -36,11 +36,10 @@ class ScheduleRepositoryImpl implements ScheduleRepository {
   /// refresh を突き抜けて AsyncLoading のまま固着する。
   @override
   Future<ScheduleResponse?> getCached() async {
-    final selection = await stopSelectionRepository.load();
-
-    // 読み出しも変換もまとめて包む。どこで失敗してもミス扱いにして下へ落とす。
+    // メソッド全体を包む。選択の読み出しを含め、どこで失敗してもミス扱いにする。
     // 取得経路（fetchSchedule）は従来どおり loud に失敗する
     try {
+      final selection = await stopSelectionRepository.load();
       final cached = await localSource.load(selection.query);
       if (cached != null) return cached.toEntity();
     } catch (_) {

--- a/flutter_app/lib/data/repositories/schedule_repository_impl.dart
+++ b/flutter_app/lib/data/repositories/schedule_repository_impl.dart
@@ -37,17 +37,21 @@ class ScheduleRepositoryImpl implements ScheduleRepository {
   @override
   Future<ScheduleResponse?> getCached() async {
     final selection = await stopSelectionRepository.load();
-    final cached = await localSource.load(selection.query);
-    if (cached != null) {
-      try {
-        return cached.toEntity();
-      } catch (_) {
-        // 解釈できないキャッシュはクラッシュではなくミス扱いにして下へ落とす。
-        // 取得経路（fetchSchedule）は従来どおり loud に失敗する
-      }
+
+    // 読み出しも変換もまとめて包む。どこで失敗してもミス扱いにして下へ落とす。
+    // 取得経路（fetchSchedule）は従来どおり loud に失敗する
+    try {
+      final cached = await localSource.load(selection.query);
+      if (cached != null) return cached.toEntity();
+    } catch (_) {
+      // 次の経路へ
     }
 
     // #177 以前のキャッシュがあれば読む（移行用・v1.4.0 で削除 / #186）
-    return localSource.loadLegacy();
+    try {
+      return await localSource.loadLegacy();
+    } catch (_) {
+      return null;
+    }
   }
 }

--- a/flutter_app/lib/data/sources/schedule_local_source.dart
+++ b/flutter_app/lib/data/sources/schedule_local_source.dart
@@ -78,12 +78,13 @@ class ScheduleLocalSource {
 
   BusEntry _legacyEntry(Map<String, dynamic> json) => BusEntry(
         time: json['time'] as String,
-        direction: switch (json['direction'] as String?) {
-          'from_minami_chitose' => BusDirection.fromMinamiChitose,
-          'from_kenkyuto_to_honbuto' => BusDirection.fromKenkyutoToHonbuto,
-          'from_kenkyuto_to_station' => BusDirection.fromKenkyutoToStation,
-          'from_honbuto' => BusDirection.fromHonbuto,
-          _ => BusDirection.fromChitose,
+        // 旧形式の direction は「乗車地 × 行き先」の組。乗車地だけを取り出す
+        boardingStopId: switch (json['direction'] as String?) {
+          'from_minami_chitose' => 'minamiChitose',
+          'from_kenkyuto_to_honbuto' => 'kenkyuto',
+          'from_kenkyuto_to_station' => 'kenkyuto',
+          'from_honbuto' => 'honbuto',
+          _ => 'chitose',
         },
         destination: json['destination'] as String? ?? '',
         arrivals: (json['arrivals'] as Map<String, dynamic>? ?? {})

--- a/flutter_app/lib/domain/entities/bus_schedule.dart
+++ b/flutter_app/lib/domain/entities/bus_schedule.dart
@@ -157,6 +157,19 @@ abstract final class ServiceCalendar {
       (date.month == DateTime.january && date.day <= 3);
 }
 
+/// 便の行き先。GAS の `destination` がこの2つだけであることは
+/// scripts/check_gas_response.js が検査している。
+///
+/// 表記が変わると、これで絞っている画面が**黙って空になる**。
+/// リテラルを散らさず、変更箇所を1つに保つためここに置く。
+abstract final class BusDestination {
+  /// 科技大（研究棟・本部棟）方面
+  static const campus = '科技大';
+
+  /// 千歳駅方面
+  static const station = '千歳駅';
+}
+
 /// ある停留所から乗る場合の1便。
 ///
 /// 便そのものではなく「どこから乗るか」を決めたあとの見え方を表す。
@@ -198,15 +211,16 @@ class BusEntry {
   /// #177 以前は `BusDirection` の名前を使っていたため、その5通りは同じ文字列に
   /// なるようにしてある。新しい停留所は該当が無いので `<乗車地>_<行き先>` を使う。
   ///
-  /// TODO(#187): 任意の停留所に対応したら形式を統一し、保存済みキーを移行する。
+  /// TODO(#190): 系統が入っておらず同時刻の便で衝突する。形式を統一する際に
+  /// 保存済みキーの移行も要る。
   String get notificationKey {
     final legacy = switch ((boardingStopId, destination)) {
       // 旧 BusDirection の enum 名（.name）。JSON の文字列ではない
-      ('chitose', '科技大') => 'fromChitose',
-      ('minamiChitose', '科技大') => 'fromMinamiChitose',
-      ('kenkyuto', '科技大') => 'fromKenkyutoToHonbuto',
-      ('kenkyuto', '千歳駅') => 'fromKenkyutoToStation',
-      ('honbuto', '千歳駅') => 'fromHonbuto',
+      ('chitose', BusDestination.campus) => 'fromChitose',
+      ('minamiChitose', BusDestination.campus) => 'fromMinamiChitose',
+      ('kenkyuto', BusDestination.campus) => 'fromKenkyutoToHonbuto',
+      ('kenkyuto', BusDestination.station) => 'fromKenkyutoToStation',
+      ('honbuto', BusDestination.station) => 'fromHonbuto',
       _ => null,
     };
     return '${legacy ?? '${boardingStopId}_$destination'}_$time';

--- a/flutter_app/lib/domain/entities/bus_schedule.dart
+++ b/flutter_app/lib/domain/entities/bus_schedule.dart
@@ -1,11 +1,3 @@
-enum BusDirection {
-  fromChitose,
-  fromMinamiChitose,
-  fromKenkyutoToHonbuto,
-  fromKenkyutoToStation,
-  fromHonbuto,
-}
-
 /// ダイヤ種別（平日 / 土日祝日）
 enum DayType {
   weekday,
@@ -165,10 +157,14 @@ abstract final class ServiceCalendar {
       (date.month == DateTime.january && date.day <= 3);
 }
 
+/// ある停留所から乗る場合の1便。
+///
+/// 便そのものではなく「どこから乗るか」を決めたあとの見え方を表す。
+/// 同じ便でも乗車地が違えば別の BusEntry になる（時刻も到着地も変わる）。
 class BusEntry {
   const BusEntry({
     required this.time,
-    required this.direction,
+    required this.boardingStopId,
     required this.destination,
     this.arrivals = const {},
     this.routeLabel,
@@ -179,8 +175,8 @@ class BusEntry {
     this.vacationOnly = false,
   });
 
-  final String time; // "HH:MM"
-  final BusDirection direction;
+  final String time; // "HH:MM" 乗車地を出る時刻
+  final String boardingStopId;
   final String destination;
   final Map<String, String> arrivals;
   final String? routeLabel;
@@ -193,6 +189,28 @@ class BusEntry {
 
   /// 学休期のみ運行（授業期は運休）
   final bool vacationOnly;
+
+  /// 通知の識別に使うキー。**形式を変えないこと。**
+  ///
+  /// SharedPreferences に保存され、OS に予約した通知の ID の元にもなる。
+  /// 変えると既存の予約が引き当てられなくなり、キャンセルできない通知が残る。
+  ///
+  /// #177 以前は `BusDirection` の名前を使っていたため、その5通りは同じ文字列に
+  /// なるようにしてある。新しい停留所は該当が無いので `<乗車地>_<行き先>` を使う。
+  ///
+  /// TODO(#187): 任意の停留所に対応したら形式を統一し、保存済みキーを移行する。
+  String get notificationKey {
+    final legacy = switch ((boardingStopId, destination)) {
+      // 旧 BusDirection の enum 名（.name）。JSON の文字列ではない
+      ('chitose', '科技大') => 'fromChitose',
+      ('minamiChitose', '科技大') => 'fromMinamiChitose',
+      ('kenkyuto', '科技大') => 'fromKenkyutoToHonbuto',
+      ('kenkyuto', '千歳駅') => 'fromKenkyutoToStation',
+      ('honbuto', '千歳駅') => 'fromHonbuto',
+      _ => null,
+    };
+    return '${legacy ?? '${boardingStopId}_$destination'}_$time';
+  }
 
   bool runsOn(DayType dayType, SeasonType season) {
     if (dayType == DayType.weekendHoliday && weekdayOnly) return false;
@@ -238,11 +256,12 @@ class BusTimetable {
   final List<BusEntry> schedules;
   final String pdfUrl;
 
-  BusEntry? nextBus(BusDirection direction, {DateTime? now}) {
+  BusEntry? nextBus(String stopId, {String? destination, DateTime? now}) {
     final current = now ?? DateTime.now();
     final candidates = schedules
         .where((e) =>
-            e.direction == direction &&
+            e.boardingStopId == stopId &&
+            (destination == null || e.destination == destination) &&
             e.isRunningToday(current) &&
             e.toDateTimeToday(now: current).isAfter(current))
         .toList()
@@ -250,23 +269,33 @@ class BusTimetable {
     return candidates.firstOrNull;
   }
 
-  List<BusEntry> todayBuses(BusDirection direction, {DateTime? now}) {
+  List<BusEntry> todayBuses(String stopId,
+      {String? destination, DateTime? now}) {
     final current = now ?? DateTime.now();
     if (ServiceCalendar.isSuspended(current)) return const [];
     return busesFor(
-      direction,
+      stopId,
       DayType.fromDate(current),
       SeasonType.fromDate(current),
+      destination: destination,
     );
   }
 
+  /// [stopId] から乗る便。
+  ///
+  /// [destination] を指定すると行き先で絞る。途中の停留所は上下両方向のバスが
+  /// 通るため、画面に出すときは指定しないと逆方向の便が混ざる。
   List<BusEntry> busesFor(
-    BusDirection direction,
+    String stopId,
     DayType dayType,
-    SeasonType season,
-  ) {
+    SeasonType season, {
+    String? destination,
+  }) {
     final filtered = schedules
-        .where((e) => e.direction == direction && e.runsOn(dayType, season))
+        .where((e) =>
+            e.boardingStopId == stopId &&
+            (destination == null || e.destination == destination) &&
+            e.runsOn(dayType, season))
         .toList();
     filtered.sort((a, b) => a.time.compareTo(b.time));
     return filtered;
@@ -280,11 +309,20 @@ class BusStop {
   const BusStop({
     required this.id,
     required this.label,
+    this.shortLabel,
     this.boardable = true,
   });
 
   final String id;
+
+  /// 正式名（バス停の表記）
   final String label;
+
+  /// タブなど幅の狭い場所で使う短縮名。正式名と同じなら GAS は返さない
+  final String? shortLabel;
+
+  /// 表示に使う名前
+  String get displayLabel => shortLabel ?? label;
 
   /// 乗車地として選べるか。
   /// ラピダス前は工場敷地内で一般利用できないため false。

--- a/flutter_app/lib/domain/services/notification_service.dart
+++ b/flutter_app/lib/domain/services/notification_service.dart
@@ -3,7 +3,7 @@ import '../entities/notification_settings.dart';
 
 abstract class NotificationService {
   static int busNotificationId(BusEntry bus) =>
-      '${bus.direction.name}_${bus.time}'.hashCode & 0x7FFFFFFF;
+      bus.notificationKey.hashCode & 0x7FFFFFFF;
 
   Future<bool> requestPermission();
   Future<void> scheduleNotification(BusEntry bus, NotificationSettings settings);

--- a/flutter_app/lib/presentation/viewmodels/notification_viewmodel.dart
+++ b/flutter_app/lib/presentation/viewmodels/notification_viewmodel.dart
@@ -46,7 +46,7 @@ class NotificationSettingsNotifier
     await saveSettings(current.copyWith(enabled: granted));
   }
 
-  static String busKey(BusEntry bus) => '${bus.direction.name}_${bus.time}';
+  static String busKey(BusEntry bus) => bus.notificationKey;
 
   Future<void> toggleBusNotification(BusEntry bus) async {
     final settingsState = state;

--- a/flutter_app/lib/presentation/views/home_screen.dart
+++ b/flutter_app/lib/presentation/views/home_screen.dart
@@ -299,10 +299,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
                     child: TabBarView(
                       controller: _tabController,
                       children: [
-                        _DirectionTab(timetable: result.data.current, direction: BusDirection.fromChitose, updatedAt: result.data.updatedAt, dayType: dayType, season: season),
-                        _DirectionTab(timetable: result.data.current, direction: BusDirection.fromMinamiChitose, updatedAt: result.data.updatedAt, dayType: dayType, season: season),
+                        _DirectionTab(timetable: result.data.current, stopId: 'chitose', destination: '科技大', updatedAt: result.data.updatedAt, dayType: dayType, season: season),
+                        _DirectionTab(timetable: result.data.current, stopId: 'minamiChitose', destination: '科技大', updatedAt: result.data.updatedAt, dayType: dayType, season: season),
                         _KenkyutoTab(timetable: result.data.current, updatedAt: result.data.updatedAt, dayType: dayType, season: season),
-                        _DirectionTab(timetable: result.data.current, direction: BusDirection.fromHonbuto, updatedAt: result.data.updatedAt, dayType: dayType, season: season),
+                        _DirectionTab(timetable: result.data.current, stopId: 'honbuto', destination: '千歳駅', updatedAt: result.data.updatedAt, dayType: dayType, season: season),
                       ],
                     ),
                   ),
@@ -420,23 +420,23 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
               const SizedBox(height: 16),
               const Text('千歳駅発', style: TextStyle(color: AppColors.primary, fontSize: 12, letterSpacing: 3)),
               const SizedBox(height: 8),
-              ScheduleList(timetable: upcoming, direction: BusDirection.fromChitose),
+              ScheduleList(timetable: upcoming, stopId: 'chitose', destination: '科技大'),
               const SizedBox(height: 16),
               const Text('南千歳発', style: TextStyle(color: AppColors.primary, fontSize: 12, letterSpacing: 3)),
               const SizedBox(height: 8),
-              ScheduleList(timetable: upcoming, direction: BusDirection.fromMinamiChitose),
+              ScheduleList(timetable: upcoming, stopId: 'minamiChitose', destination: '科技大'),
               const SizedBox(height: 16),
               const Text('研究棟発 → 本部棟', style: TextStyle(color: AppColors.primary, fontSize: 12, letterSpacing: 3)),
               const SizedBox(height: 8),
-              ScheduleList(timetable: upcoming, direction: BusDirection.fromKenkyutoToHonbuto),
+              ScheduleList(timetable: upcoming, stopId: 'kenkyuto', destination: '科技大'),
               const SizedBox(height: 16),
               const Text('研究棟発 → 千歳駅', style: TextStyle(color: AppColors.primary, fontSize: 12, letterSpacing: 3)),
               const SizedBox(height: 8),
-              ScheduleList(timetable: upcoming, direction: BusDirection.fromKenkyutoToStation),
+              ScheduleList(timetable: upcoming, stopId: 'kenkyuto', destination: '千歳駅'),
               const SizedBox(height: 16),
               const Text('本部棟発', style: TextStyle(color: AppColors.primary, fontSize: 12, letterSpacing: 3)),
               const SizedBox(height: 8),
-              ScheduleList(timetable: upcoming, direction: BusDirection.fromHonbuto),
+              ScheduleList(timetable: upcoming, stopId: 'honbuto', destination: '千歳駅'),
             ],
           ),
         ),
@@ -535,7 +535,8 @@ class _KenkyutoTab extends StatefulWidget {
 }
 
 class _KenkyutoTabState extends State<_KenkyutoTab> {
-  BusDirection _direction = BusDirection.fromKenkyutoToHonbuto;
+  // 研究棟は途中の停留所なので、上下どちらへ乗るかを選ばせる
+  String _destination = '科技大';
 
   @override
   Widget build(BuildContext context) {
@@ -549,20 +550,20 @@ class _KenkyutoTabState extends State<_KenkyutoTab> {
         // SegmentedButton で本部棟/千歳駅を切り替え
         Padding(
           padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
-          child: SegmentedButton<BusDirection>(
+          child: SegmentedButton<String>(
             segments: const [
               ButtonSegment(
-                value: BusDirection.fromKenkyutoToHonbuto,
+                value: '科技大',
                 label: Text('→ 本部棟'),
               ),
               ButtonSegment(
-                value: BusDirection.fromKenkyutoToStation,
+                value: '千歳駅',
                 label: Text('→ 千歳駅'),
               ),
             ],
-            selected: {_direction},
+            selected: {_destination},
             onSelectionChanged: (selection) =>
-                setState(() => _direction = selection.first),
+                setState(() => _destination = selection.first),
             style: SegmentedButton.styleFrom(
               backgroundColor: context.appColors.surface,
               foregroundColor: context.appColors.textTertiary,
@@ -588,10 +589,10 @@ class _KenkyutoTabState extends State<_KenkyutoTab> {
                 GestureDetector(
                   onVerticalDragUpdate: (_) {},
                   child: IndexedStack(
-                    index: _direction == BusDirection.fromKenkyutoToHonbuto ? 0 : 1,
+                    index: _destination == '科技大' ? 0 : 1,
                     children: [
-                      NextBusDisplay(timetable: widget.timetable, direction: BusDirection.fromKenkyutoToHonbuto),
-                      NextBusDisplay(timetable: widget.timetable, direction: BusDirection.fromKenkyutoToStation),
+                      NextBusDisplay(timetable: widget.timetable, stopId: 'kenkyuto', destination: '科技大'),
+                      NextBusDisplay(timetable: widget.timetable, stopId: 'kenkyuto', destination: '千歳駅'),
                     ],
                   ),
                 ),
@@ -613,13 +614,13 @@ class _KenkyutoTabState extends State<_KenkyutoTab> {
           child: GestureDetector(
             onVerticalDragUpdate: (_) {},
             child: IndexedStack(
-              index: _direction == BusDirection.fromKenkyutoToHonbuto ? 0 : 1,
+              index: _destination == '科技大' ? 0 : 1,
               children: [
                 ScheduleList(
                   key: PageStorageKey(
                       'kenkyuto_honbuto_${widget.dayType?.name ?? 'today'}_${widget.season?.name ?? ''}'),
                   timetable: widget.timetable,
-                  direction: BusDirection.fromKenkyutoToHonbuto,
+                  stopId: 'kenkyuto', destination: '科技大',
                   dayType: widget.dayType,
                   season: widget.season,
                 ),
@@ -627,7 +628,7 @@ class _KenkyutoTabState extends State<_KenkyutoTab> {
                   key: PageStorageKey(
                       'kenkyuto_chitose_${widget.dayType?.name ?? 'today'}_${widget.season?.name ?? ''}'),
                   timetable: widget.timetable,
-                  direction: BusDirection.fromKenkyutoToStation,
+                  stopId: 'kenkyuto', destination: '千歳駅',
                   dayType: widget.dayType,
                   season: widget.season,
                 ),
@@ -650,14 +651,16 @@ class _KenkyutoTabState extends State<_KenkyutoTab> {
 class _DirectionTab extends StatelessWidget {
   const _DirectionTab({
     required this.timetable,
-    required this.direction,
+    required this.stopId,
+    required this.destination,
     required this.updatedAt,
     this.dayType,
     this.season,
   });
 
   final BusTimetable timetable;
-  final BusDirection direction;
+  final String stopId;
+  final String destination;
   final String updatedAt;
   final DayType? dayType;
   final SeasonType? season;
@@ -697,8 +700,9 @@ class _DirectionTab extends StatelessWidget {
                   onVerticalDragUpdate: (_) {},
                   child: NextBusDisplay(
                     timetable: timetable,
-                    direction: direction,
-                    showPlatform: direction == BusDirection.fromChitose,
+                    stopId: stopId,
+                    destination: destination,
+                    showPlatform: stopId == 'chitose',
                   ),
                 ),
                 const SizedBox(height: 24),
@@ -725,9 +729,10 @@ class _DirectionTab extends StatelessWidget {
             // 当日表示に戻ったとき NEXT への自動スクロールを再実行させる。
             child: ScheduleList(
               key: ValueKey(
-                  '${direction.name}_${dayType?.name ?? 'today'}_${season?.name ?? ''}'),
+                  '${stopId}_${destination}_${dayType?.name ?? 'today'}_${season?.name ?? ''}'),
               timetable: timetable,
-              direction: direction,
+              stopId: stopId,
+              destination: destination,
               dayType: dayType,
               season: season,
             ),

--- a/flutter_app/lib/presentation/views/home_screen.dart
+++ b/flutter_app/lib/presentation/views/home_screen.dart
@@ -299,10 +299,10 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
                     child: TabBarView(
                       controller: _tabController,
                       children: [
-                        _DirectionTab(timetable: result.data.current, stopId: 'chitose', destination: '科技大', updatedAt: result.data.updatedAt, dayType: dayType, season: season),
-                        _DirectionTab(timetable: result.data.current, stopId: 'minamiChitose', destination: '科技大', updatedAt: result.data.updatedAt, dayType: dayType, season: season),
+                        _DirectionTab(timetable: result.data.current, stopId: 'chitose', destination: BusDestination.campus, updatedAt: result.data.updatedAt, dayType: dayType, season: season),
+                        _DirectionTab(timetable: result.data.current, stopId: 'minamiChitose', destination: BusDestination.campus, updatedAt: result.data.updatedAt, dayType: dayType, season: season),
                         _KenkyutoTab(timetable: result.data.current, updatedAt: result.data.updatedAt, dayType: dayType, season: season),
-                        _DirectionTab(timetable: result.data.current, stopId: 'honbuto', destination: '千歳駅', updatedAt: result.data.updatedAt, dayType: dayType, season: season),
+                        _DirectionTab(timetable: result.data.current, stopId: 'honbuto', destination: BusDestination.station, updatedAt: result.data.updatedAt, dayType: dayType, season: season),
                       ],
                     ),
                   ),
@@ -420,23 +420,23 @@ class _HomeScreenState extends ConsumerState<HomeScreen>
               const SizedBox(height: 16),
               const Text('千歳駅発', style: TextStyle(color: AppColors.primary, fontSize: 12, letterSpacing: 3)),
               const SizedBox(height: 8),
-              ScheduleList(timetable: upcoming, stopId: 'chitose', destination: '科技大'),
+              ScheduleList(timetable: upcoming, stopId: 'chitose', destination: BusDestination.campus),
               const SizedBox(height: 16),
               const Text('南千歳発', style: TextStyle(color: AppColors.primary, fontSize: 12, letterSpacing: 3)),
               const SizedBox(height: 8),
-              ScheduleList(timetable: upcoming, stopId: 'minamiChitose', destination: '科技大'),
+              ScheduleList(timetable: upcoming, stopId: 'minamiChitose', destination: BusDestination.campus),
               const SizedBox(height: 16),
               const Text('研究棟発 → 本部棟', style: TextStyle(color: AppColors.primary, fontSize: 12, letterSpacing: 3)),
               const SizedBox(height: 8),
-              ScheduleList(timetable: upcoming, stopId: 'kenkyuto', destination: '科技大'),
+              ScheduleList(timetable: upcoming, stopId: 'kenkyuto', destination: BusDestination.campus),
               const SizedBox(height: 16),
               const Text('研究棟発 → 千歳駅', style: TextStyle(color: AppColors.primary, fontSize: 12, letterSpacing: 3)),
               const SizedBox(height: 8),
-              ScheduleList(timetable: upcoming, stopId: 'kenkyuto', destination: '千歳駅'),
+              ScheduleList(timetable: upcoming, stopId: 'kenkyuto', destination: BusDestination.station),
               const SizedBox(height: 16),
               const Text('本部棟発', style: TextStyle(color: AppColors.primary, fontSize: 12, letterSpacing: 3)),
               const SizedBox(height: 8),
-              ScheduleList(timetable: upcoming, stopId: 'honbuto', destination: '千歳駅'),
+              ScheduleList(timetable: upcoming, stopId: 'honbuto', destination: BusDestination.station),
             ],
           ),
         ),
@@ -536,7 +536,7 @@ class _KenkyutoTab extends StatefulWidget {
 
 class _KenkyutoTabState extends State<_KenkyutoTab> {
   // 研究棟は途中の停留所なので、上下どちらへ乗るかを選ばせる
-  String _destination = '科技大';
+  String _destination = BusDestination.campus;
 
   @override
   Widget build(BuildContext context) {
@@ -553,11 +553,11 @@ class _KenkyutoTabState extends State<_KenkyutoTab> {
           child: SegmentedButton<String>(
             segments: const [
               ButtonSegment(
-                value: '科技大',
+                value: BusDestination.campus,
                 label: Text('→ 本部棟'),
               ),
               ButtonSegment(
-                value: '千歳駅',
+                value: BusDestination.station,
                 label: Text('→ 千歳駅'),
               ),
             ],
@@ -589,10 +589,10 @@ class _KenkyutoTabState extends State<_KenkyutoTab> {
                 GestureDetector(
                   onVerticalDragUpdate: (_) {},
                   child: IndexedStack(
-                    index: _destination == '科技大' ? 0 : 1,
+                    index: _destination == BusDestination.campus ? 0 : 1,
                     children: [
-                      NextBusDisplay(timetable: widget.timetable, stopId: 'kenkyuto', destination: '科技大'),
-                      NextBusDisplay(timetable: widget.timetable, stopId: 'kenkyuto', destination: '千歳駅'),
+                      NextBusDisplay(timetable: widget.timetable, stopId: 'kenkyuto', destination: BusDestination.campus),
+                      NextBusDisplay(timetable: widget.timetable, stopId: 'kenkyuto', destination: BusDestination.station),
                     ],
                   ),
                 ),
@@ -614,13 +614,13 @@ class _KenkyutoTabState extends State<_KenkyutoTab> {
           child: GestureDetector(
             onVerticalDragUpdate: (_) {},
             child: IndexedStack(
-              index: _destination == '科技大' ? 0 : 1,
+              index: _destination == BusDestination.campus ? 0 : 1,
               children: [
                 ScheduleList(
                   key: PageStorageKey(
                       'kenkyuto_honbuto_${widget.dayType?.name ?? 'today'}_${widget.season?.name ?? ''}'),
                   timetable: widget.timetable,
-                  stopId: 'kenkyuto', destination: '科技大',
+                  stopId: 'kenkyuto', destination: BusDestination.campus,
                   dayType: widget.dayType,
                   season: widget.season,
                 ),
@@ -628,7 +628,7 @@ class _KenkyutoTabState extends State<_KenkyutoTab> {
                   key: PageStorageKey(
                       'kenkyuto_chitose_${widget.dayType?.name ?? 'today'}_${widget.season?.name ?? ''}'),
                   timetable: widget.timetable,
-                  stopId: 'kenkyuto', destination: '千歳駅',
+                  stopId: 'kenkyuto', destination: BusDestination.station,
                   dayType: widget.dayType,
                   season: widget.season,
                 ),

--- a/flutter_app/lib/presentation/views/widgets/next_bus_display.dart
+++ b/flutter_app/lib/presentation/views/widgets/next_bus_display.dart
@@ -9,24 +9,46 @@ class NextBusDisplay extends ConsumerWidget {
   const NextBusDisplay({
     super.key,
     required this.timetable,
-    required this.direction,
+    required this.stopId,
+    this.destination,
     this.showPlatform = false,
   });
 
   final BusTimetable timetable;
-  final BusDirection direction;
+
+  /// 乗車地
+  final String stopId;
+
+  /// 行き先（科技大 / 千歳駅）。指定しなければ絞らない。
+  /// 途中の停留所は上下両方向のバスが通るため、画面では指定する
+  final String? destination;
   final bool showPlatform;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final now = ref.watch(countdownProvider);
 
-    final next = timetable.nextBus(direction, now: now);
+    final next = timetable.nextBus(stopId, destination: destination, now: now);
     if (next == null) {
       return const _NoMoreBusCard();
     }
     return _NextBusCard(entry: next, now: now, showPlatform: showPlatform);
   }
+}
+
+/// NEXT BUS に出す行き先の表示名。
+///
+/// 便の destination（科技大 / 千歳駅）をそのまま出すと、研究棟から乗る場合に
+/// 「科技大」となって現在の表示と変わる。実際に向かうのは本部棟なので、
+/// 現在は乗車地との組で決めている。
+///
+/// TODO(#177): 乗車地選択の UI を入れる際に見直す。任意の停留所では
+/// この対応表を持てないため、行き先の出し方そのものを決め直す必要がある。
+String destinationLabelOf(BusEntry entry) {
+  if (entry.boardingStopId == 'kenkyuto' && entry.destination == '科技大') {
+    return '本部棟';
+  }
+  return entry.destination;
 }
 
 class _NextBusCard extends StatelessWidget {
@@ -46,29 +68,9 @@ class _NextBusCard extends StatelessWidget {
     'chitose': '千歳駅',
   };
 
-  List<String> _getArrivalOrder(BusEntry entry) {
-    final isRoute2 = entry.routeLabel == '直通';
-    switch (entry.direction) {
-      case BusDirection.fromChitose:
-        return isRoute2
-            ? ['kenkyuto', 'honbuto']
-            : ['minamiChitose', 'kenkyuto', 'honbuto'];
-      case BusDirection.fromMinamiChitose:
-        return ['kenkyuto', 'honbuto'];
-      case BusDirection.fromKenkyutoToHonbuto:
-        return ['honbuto'];
-      case BusDirection.fromKenkyutoToStation:
-        return isRoute2 ? ['chitose'] : ['minamiChitose', 'chitose'];
-      case BusDirection.fromHonbuto:
-        return isRoute2
-            ? ['kenkyuto', 'chitose']
-            : ['kenkyuto', 'minamiChitose', 'chitose'];
-    }
-  }
-
   List<Widget> _buildArrivalRows(BusEntry entry, BuildContext context) {
     final colors = context.appColors;
-    final order = _getArrivalOrder(entry);
+    final order = entry.arrivals.keys.toList();
     return order
         .where((key) => entry.arrivals.containsKey(key))
         .map((key) => Padding(
@@ -127,13 +129,7 @@ class _NextBusCard extends StatelessWidget {
                   ),
                 ),
                 Text(
-                  switch (entry.direction) {
-                    BusDirection.fromChitose => '科技大',
-                    BusDirection.fromMinamiChitose => '科技大',
-                    BusDirection.fromKenkyutoToHonbuto => '本部棟',
-                    BusDirection.fromKenkyutoToStation => '千歳駅',
-                    BusDirection.fromHonbuto => '千歳駅',
-                  },
+                  destinationLabelOf(entry),
                   style: TextStyle(
                     color: colors.textPrimary,
                     fontSize: 14,

--- a/flutter_app/lib/presentation/views/widgets/next_bus_display.dart
+++ b/flutter_app/lib/presentation/views/widgets/next_bus_display.dart
@@ -45,7 +45,7 @@ class NextBusDisplay extends ConsumerWidget {
 /// TODO(#177): 乗車地選択の UI を入れる際に見直す。任意の停留所では
 /// この対応表を持てないため、行き先の出し方そのものを決め直す必要がある。
 String destinationLabelOf(BusEntry entry) {
-  if (entry.boardingStopId == 'kenkyuto' && entry.destination == '科技大') {
+  if (entry.boardingStopId == 'kenkyuto' && entry.destination == BusDestination.campus) {
     return '本部棟';
   }
   return entry.destination;
@@ -71,9 +71,7 @@ class _NextBusCard extends StatelessWidget {
   List<Widget> _buildArrivalRows(BusEntry entry, BuildContext context) {
     final colors = context.appColors;
     final order = entry.arrivals.keys.toList();
-    return order
-        .where((key) => entry.arrivals.containsKey(key))
-        .map((key) => Padding(
+    return order.map((key) => Padding(
               padding: const EdgeInsets.only(bottom: 4),
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/flutter_app/lib/presentation/views/widgets/schedule_list.dart
+++ b/flutter_app/lib/presentation/views/widgets/schedule_list.dart
@@ -12,13 +12,18 @@ class ScheduleList extends ConsumerStatefulWidget {
   const ScheduleList({
     super.key,
     required this.timetable,
-    required this.direction,
+    required this.stopId,
+    this.destination,
     this.dayType,
     this.season,
   });
 
   final BusTimetable timetable;
-  final BusDirection direction;
+  /// 乗車地
+  final String stopId;
+
+  /// 行き先（科技大 / 千歳駅）。指定しなければ絞らない
+  final String? destination;
 
   /// 非 null の場合、当日ではなく指定ダイヤ種別（平日 / 土日祝）の全便を表示する。
   /// このとき現在時刻に依存する表示（NEXT ハイライト・過去便のグレーアウト・
@@ -44,7 +49,7 @@ class _ScheduleListState extends ConsumerState<ScheduleList> {
   void initState() {
     super.initState();
     // スクロールは初期表示時のみ実行（didUpdateWidgetは対象外）。
-    // - direction は各タブで固定のため変化しない
+    // - stopId / destination は各タブで固定のため変化しない
     // - timetable 更新時の再スクロールは要件外（ユーザー操作の上書きを避けるため）
     WidgetsBinding.instance.addPostFrameCallback((_) {
       // 非有界コンテキスト（KenkyutoTab・来週ダイヤ等）はスクロールしない。
@@ -71,15 +76,16 @@ class _ScheduleListState extends ConsumerState<ScheduleList> {
 
     final dayType = widget.dayType;
     final buses = dayType == null
-        ? widget.timetable.todayBuses(widget.direction, now: now)
+        ? widget.timetable.todayBuses(widget.stopId, destination: widget.destination, now: now)
         : widget.timetable.busesFor(
-            widget.direction,
+            widget.stopId,
             dayType,
             widget.season ?? SeasonType.fromDate(now),
+            destination: widget.destination,
           );
     // 当日以外の表示では NEXT の概念がないため null とする
     final nextBus = dayType == null
-        ? widget.timetable.nextBus(widget.direction, now: now)
+        ? widget.timetable.nextBus(widget.stopId, destination: widget.destination, now: now)
         : null;
 
     if (buses.isEmpty) {
@@ -173,26 +179,6 @@ class _ScheduleRowState extends ConsumerState<_ScheduleRow> {
     'chitose': '千歳駅',
   };
 
-  List<String> _getArrivalOrder(BusEntry entry) {
-    final isRoute2 = entry.routeLabel == '直通';
-    switch (entry.direction) {
-      case BusDirection.fromChitose:
-        return isRoute2
-            ? ['kenkyuto', 'honbuto']
-            : ['minamiChitose', 'kenkyuto', 'honbuto'];
-      case BusDirection.fromMinamiChitose:
-        return ['kenkyuto', 'honbuto'];
-      case BusDirection.fromKenkyutoToHonbuto:
-        return ['honbuto'];
-      case BusDirection.fromKenkyutoToStation:
-        return isRoute2 ? ['chitose'] : ['minamiChitose', 'chitose'];
-      case BusDirection.fromHonbuto:
-        return isRoute2
-            ? ['kenkyuto', 'chitose']
-            : ['kenkyuto', 'minamiChitose', 'chitose'];
-    }
-  }
-
   List<Widget> _buildLectureTagWidgets() {
     final showTags =
         ref.watch(displaySettingsProvider).valueOrNull?.showLectureTags ?? true;
@@ -260,7 +246,7 @@ class _ScheduleRowState extends ConsumerState<_ScheduleRow> {
 
   List<Widget> _buildArrivalRows() {
     final colors = context.appColors;
-    final order = _getArrivalOrder(widget.bus);
+    final order = widget.bus.arrivals.keys.toList();
     return order
         .where((key) => widget.bus.arrivals.containsKey(key))
         .map((key) => Padding(

--- a/flutter_app/lib/presentation/views/widgets/schedule_list.dart
+++ b/flutter_app/lib/presentation/views/widgets/schedule_list.dart
@@ -247,9 +247,7 @@ class _ScheduleRowState extends ConsumerState<_ScheduleRow> {
   List<Widget> _buildArrivalRows() {
     final colors = context.appColors;
     final order = widget.bus.arrivals.keys.toList();
-    return order
-        .where((key) => widget.bus.arrivals.containsKey(key))
-        .map((key) => Padding(
+    return order.map((key) => Padding(
               padding: const EdgeInsets.only(top: 4, left: 8),
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/flutter_app/test/helpers/fake_schedule_local_source.dart
+++ b/flutter_app/test/helpers/fake_schedule_local_source.dart
@@ -10,6 +10,9 @@ class FakeScheduleLocalSource implements ScheduleLocalSource {
   String? storedStops;
   int saveCallCount = 0;
 
+  /// 読み出しが失敗する状況を作る（キャッシュ破損など）
+  bool failOnLoad = false;
+
   /// キャッシュを事前に置く。停留所の選択を指定しなければ既定の4停留所として扱う
   void preload(ScheduleResponseModel model, {String? stopsKey}) {
     stored = model;
@@ -17,8 +20,10 @@ class FakeScheduleLocalSource implements ScheduleLocalSource {
   }
 
   @override
-  Future<ScheduleResponseModel?> load(String stopsKey) async =>
-      storedStops == stopsKey ? stored : null;
+  Future<ScheduleResponseModel?> load(String stopsKey) async {
+    if (failOnLoad) throw const FormatException('壊れたキャッシュ');
+    return storedStops == stopsKey ? stored : null;
+  }
 
   @override
   Future<void> save(ScheduleResponseModel model, String stopsKey) async {

--- a/flutter_app/test/unit/data/bus_schedule_model_test.dart
+++ b/flutter_app/test/unit/data/bus_schedule_model_test.dart
@@ -49,43 +49,47 @@ List<BusEntry> entriesOf(List<TripModel> trips) => BusTimetableModel(
     ).toEntity().schedules;
 
 void main() {
-  group('TripModel → BusEntry の展開（v=3 時代と同じ形にする）', () {
-    test('往路は 千歳駅 / 南千歳 / 研究棟 の3件に展開される', () {
+  group('TripModel → BusEntry の展開', () {
+    test('終点を除く全ての停留所が乗車地になる', () {
+      // 終点は後に停留所が無いので乗車地にならない
       final entries = entriesOf([_outbound]);
-      expect(entries.map((e) => e.direction), [
-        BusDirection.fromChitose,
-        BusDirection.fromMinamiChitose,
-        BusDirection.fromKenkyutoToHonbuto,
+      expect(entries.map((e) => e.boardingStopId), [
+        'chitose',
+        'morimoto',
+        'minamiChitose',
+        'kenkyuto',
       ]);
-      expect(entries.map((e) => e.time), ['07:20', '07:31', '07:44']);
+      expect(entries.map((e) => e.time), ['07:20', '07:23', '07:31', '07:44']);
     });
 
-    test('復路は 本部棟 / 研究棟 の2件のみ（南千歳・千歳は乗車地にしない）', () {
+    test('復路も同じく終点以外が乗車地になる', () {
       final entries = entriesOf([_inbound]);
-      expect(entries.map((e) => e.direction), [
-        BusDirection.fromHonbuto,
-        BusDirection.fromKenkyutoToStation,
+      expect(entries.map((e) => e.boardingStopId), [
+        'honbuto',
+        'kenkyuto',
+        'minamiChitose',
       ]);
-      expect(entries.map((e) => e.time), ['11:36', '11:39']);
+      expect(entries.map((e) => e.time), ['11:36', '11:39', '11:51']);
     });
 
-    test('arrivals は乗車地より後の4停留所だけを通過順に持つ', () {
+    test('arrivals は乗車地より後の停留所を通過順に持つ', () {
       final entries = entriesOf([_outbound]);
       expect(entries[0].arrivals, {
+        'morimoto': '07:23',
         'minamiChitose': '07:31',
         'kenkyuto': '07:44',
         'honbuto': '07:45',
       });
-      expect(entries[1].arrivals, {'kenkyuto': '07:44', 'honbuto': '07:45'});
-      expect(entries[2].arrivals, {'honbuto': '07:45'});
+      expect(entries.last.arrivals, {'honbuto': '07:45'});
     });
 
-    test('4停留所以外（もりもと本店前）は arrivals に混ざらない', () {
-      // pr-c では表示を変えない。途中停留所を出すのは UI 対応の後
+    test('途中の停留所も乗車地・到着地として扱える', () {
+      // #177 の目的。もりもと本店前から乗る便が引ける
       final entries = entriesOf([_outbound]);
-      for (final e in entries) {
-        expect(e.arrivals.containsKey('morimoto'), isFalse);
-      }
+      final fromMorimoto =
+          entries.firstWhere((e) => e.boardingStopId == 'morimoto');
+      expect(fromMorimoto.time, '07:23');
+      expect(fromMorimoto.arrivals.keys, ['minamiChitose', 'kenkyuto', 'honbuto']);
     });
 
     test('復路の arrivals も通過順（研究棟 → 南千歳 → 千歳駅）', () {
@@ -95,11 +99,17 @@ void main() {
       expect(entries[1].arrivals.keys.toList(), ['minamiChitose', 'chitose']);
     });
 
+    test('のりばは乗車地のものだけが付く', () {
+      final entries = entriesOf([_outbound]);
+      expect(entries.first.platformNumber, '5番');
+      expect(entries[1].platformNumber, isNull);
+    });
+
     test('通らない停留所は arrivals に現れない（直通は南千歳を経由しない）', () {
       final entries = entriesOf([_direct]);
-      expect(entries.map((e) => e.direction), [
-        BusDirection.fromChitose,
-        BusDirection.fromKenkyutoToHonbuto,
+      expect(entries.map((e) => e.boardingStopId), [
+        'chitose',
+        'kenkyuto',
       ]);
       expect(entries[0].arrivals, {'kenkyuto': '07:32', 'honbuto': '07:35'});
     });
@@ -129,22 +139,8 @@ void main() {
       }
     });
 
-    test('知らない行き先は黙って捨てず例外にする', () {
-      // 空を返すとその系統の便がエラーも出さず全部消え、「バスがありません」に
-      // なってしまう。GAS 側の destination を増やしたら気付けるようにする
-      expect(
-        () => entriesOf([
-          const TripModel(
-            destination: '長都駅',
-            stops: [StopTimeModel(id: 'chitose', time: '21:00')],
-          ),
-        ]),
-        throwsA(isA<FormatException>()),
-      );
-    });
-
-    test('乗車地を1つも含まない便は展開されない', () {
-      // 利用者が4停留所以外だけを選ぶと起きる。pr-c では選択を変えないので通常は無い
+    test('停留所が1つだけの便は展開されない', () {
+      // 選んだ停留所を1つしか通らない便。乗っても降りる先が無い
       final entries = entriesOf([
         const TripModel(
           destination: '科技大',
@@ -217,7 +213,7 @@ void main() {
       expect(model.current.trips.single.stops.first.platform, '5番');
 
       final entries = model.toEntity().current.schedules;
-      expect(entries.single.direction, BusDirection.fromChitose);
+      expect(entries.single.boardingStopId, 'chitose');
       expect(entries.single.arrivals, {'honbuto': '07:45'});
     });
   });

--- a/flutter_app/test/unit/data/local_notification_service_test.dart
+++ b/flutter_app/test/unit/data/local_notification_service_test.dart
@@ -7,7 +7,7 @@ void main() {
     test('同じ便は同じIDを返す', () {
       const bus = BusEntry(
         time: '08:30',
-        direction: BusDirection.fromChitose,
+        boardingStopId: 'chitose',
         destination: '千歳駅',
       );
       final id1 = NotificationService.busNotificationId(bus);
@@ -18,12 +18,12 @@ void main() {
     test('時刻が同じでも方面が異なれば異なるIDを返す', () {
       const busA = BusEntry(
         time: '08:30',
-        direction: BusDirection.fromChitose,
+        boardingStopId: 'chitose',
         destination: '千歳駅',
       );
       const busB = BusEntry(
         time: '08:30',
-        direction: BusDirection.fromHonbuto,
+        boardingStopId: 'honbuto',
         destination: '本部棟',
       );
       expect(
@@ -35,7 +35,7 @@ void main() {
     test('IDは非負の整数', () {
       const bus = BusEntry(
         time: '23:59',
-        direction: BusDirection.fromMinamiChitose,
+        boardingStopId: 'minamiChitose',
         destination: '南千歳駅',
       );
       final id = NotificationService.busNotificationId(bus);

--- a/flutter_app/test/unit/data/schedule_local_source_test.dart
+++ b/flutter_app/test/unit/data/schedule_local_source_test.dart
@@ -13,7 +13,7 @@ const _responseModel = ScheduleResponseModel(
     validTo: '2024-03-31',
     trips: [
       TripModel(
-        destination: '千歳科技大',
+        destination: '科技大',
         stops: [StopTimeModel(id: 'chitose', time: '09:30')],
       ),
     ],

--- a/flutter_app/test/unit/data/schedule_repository_impl_test.dart
+++ b/flutter_app/test/unit/data/schedule_repository_impl_test.dart
@@ -177,7 +177,7 @@ void main() {
         schedules: [
           BusEntry(
             time: '07:20',
-            direction: BusDirection.fromChitose,
+            boardingStopId: 'chitose',
             destination: '科技大',
             arrivals: const {'honbuto': '07:45'},
           ),
@@ -208,58 +208,23 @@ void main() {
     });
   });
 
-  group('解釈できない応答の扱い', () {
-    // GAS が想定外の destination を返したときの経路。
-    // check_gas_response.js が本来ここを止めるが、止められなかった場合の備え
-    const poisoned = ScheduleResponseModel(
-      updatedAt: '2026-08-10',
-      current: BusTimetableModel(
-        trips: [
-          TripModel(
-            destination: '長都駅',
-            stops: [StopTimeModel(id: 'chitose', time: '21:00')],
-          ),
-        ],
-      ),
-    );
-
-    test('取得経路は例外を投げる（黙って消さない）', () async {
-      when(() => mockRemoteSource.fetchSchedule(any()))
-          .thenAnswer((_) async => poisoned);
-
-      expect(() => repository.fetchSchedule(), throwsA(isA<FormatException>()));
-    });
-
-    test('解釈できない応答はキャッシュに保存しない', () async {
-      // 先に保存すると、以降のキャッシュ読み出しが毎回失敗するようになる
-      when(() => mockRemoteSource.fetchSchedule(any()))
-          .thenAnswer((_) async => poisoned);
-
-      await expectLater(repository.fetchSchedule(), throwsA(isA<Exception>()));
-      expect(fakeLocalSource.stored, isNull);
-      expect(fakeLocalSource.saveCallCount, 0);
-    });
-
-    test('解釈できないキャッシュは投げずに null を返す', () async {
-      // getCached は復帰手段なので投げてはいけない（投げると画面が固まる）
-      fakeLocalSource.preload(poisoned);
+  group('キャッシュ読み出しが失敗しても getCached は投げない', () {
+    // getCached は取得失敗後の復帰手段として呼ばれる。ここで投げると
+    // 呼び出し側の catch を突き抜けて画面が AsyncLoading のまま固まる
+    test('読み出しが例外を投げても null を返す', () async {
+      fakeLocalSource.failOnLoad = true;
 
       expect(await repository.getCached(), isNull);
     });
 
-    test('解釈できないキャッシュでも旧キャッシュがあればそちらを返す', () async {
-      fakeLocalSource.preload(poisoned);
+    test('読み出しが失敗しても旧キャッシュがあればそちらを返す', () async {
+      fakeLocalSource.failOnLoad = true;
       fakeLocalSource.legacy = ScheduleResponse(
         updatedAt: '2026-08-01',
-        current: const BusTimetable(
-          validFrom: '',
-          validTo: '',
-          schedules: [],
-        ),
+        current: const BusTimetable(validFrom: '', validTo: '', schedules: []),
       );
 
-      // preload で storedStops が入るため、この経路では旧キャッシュは使われない
-      expect(await repository.getCached(), isNull);
+      expect((await repository.getCached())?.updatedAt, '2026-08-01');
     });
   });
 }

--- a/flutter_app/test/unit/domain/bus_entry_test.dart
+++ b/flutter_app/test/unit/domain/bus_entry_test.dart
@@ -10,8 +10,8 @@ void main() {
       test('returns DateTime with correct date and parsed time', () {
         const entry = BusEntry(
           time: '09:30',
-          direction: BusDirection.fromChitose,
-          destination: '千歳科技大',
+          boardingStopId: 'chitose',
+          destination: '科技大',
         );
         final result = entry.toDateTimeToday(now: fixedNow);
 
@@ -27,8 +27,8 @@ void main() {
       test('weekdayOnly=true: 平日ダイヤでは運行、土日祝ダイヤでは運休', () {
         const entry = BusEntry(
           time: '09:30',
-          direction: BusDirection.fromChitose,
-          destination: '千歳科技大',
+          boardingStopId: 'chitose',
+          destination: '科技大',
           weekdayOnly: true,
         );
         expect(entry.runsOn(DayType.weekday, SeasonType.academic), isTrue);
@@ -38,8 +38,8 @@ void main() {
       test('weekendOnly=true: 土日祝ダイヤでは運行、平日ダイヤでは運休', () {
         const entry = BusEntry(
           time: '09:30',
-          direction: BusDirection.fromChitose,
-          destination: '千歳科技大',
+          boardingStopId: 'chitose',
+          destination: '科技大',
           weekendOnly: true,
         );
         expect(entry.runsOn(DayType.weekday, SeasonType.academic), isFalse);
@@ -49,8 +49,8 @@ void main() {
       test('フラグなし: どちらのダイヤでも運行', () {
         const entry = BusEntry(
           time: '09:30',
-          direction: BusDirection.fromChitose,
-          destination: '千歳科技大',
+          boardingStopId: 'chitose',
+          destination: '科技大',
         );
         expect(entry.runsOn(DayType.weekday, SeasonType.academic), isTrue);
         expect(entry.runsOn(DayType.weekendHoliday, SeasonType.academic), isTrue);
@@ -61,8 +61,8 @@ void main() {
       test('weekdayOnly=true: 土曜日は運休、月曜日は運行', () {
         const entry = BusEntry(
           time: '09:30',
-          direction: BusDirection.fromChitose,
-          destination: '千歳科技大',
+          boardingStopId: 'chitose',
+          destination: '科技大',
           weekdayOnly: true,
         );
         final saturday = DateTime(2024, 6, 15); // 土曜日
@@ -74,8 +74,8 @@ void main() {
       test('weekendOnly=true: 月曜日は運休、日曜日は運行', () {
         const entry = BusEntry(
           time: '09:30',
-          direction: BusDirection.fromChitose,
-          destination: '千歳科技大',
+          boardingStopId: 'chitose',
+          destination: '科技大',
           weekendOnly: true,
         );
         final sunday = DateTime(2024, 6, 16); // 日曜日
@@ -89,8 +89,8 @@ void main() {
       test('returns positive value for future time', () {
         const entry = BusEntry(
           time: '13:00',
-          direction: BusDirection.fromChitose,
-          destination: '千歳科技大',
+          boardingStopId: 'chitose',
+          destination: '科技大',
         );
         // fixedNow = 12:00, entry = 13:00 → +60 minutes
         expect(entry.minutesFromNow(now: fixedNow), equals(60));
@@ -99,8 +99,8 @@ void main() {
       test('returns negative value for past time', () {
         const entry = BusEntry(
           time: '11:00',
-          direction: BusDirection.fromChitose,
-          destination: '千歳科技大',
+          boardingStopId: 'chitose',
+          destination: '科技大',
         );
         // fixedNow = 12:00, entry = 11:00 → -60 minutes
         expect(entry.minutesFromNow(now: fixedNow), equals(-60));
@@ -109,8 +109,8 @@ void main() {
       test('returns 0 for exact current time (boundary)', () {
         const entry = BusEntry(
           time: '12:00',
-          direction: BusDirection.fromChitose,
-          destination: '千歳科技大',
+          boardingStopId: 'chitose',
+          destination: '科技大',
         );
         // fixedNow = 12:00:00, entry = 12:00 → 0 seconds diff → 0 minutes
         expect(entry.minutesFromNow(now: fixedNow), equals(0));

--- a/flutter_app/test/unit/domain/bus_timetable_test.dart
+++ b/flutter_app/test/unit/domain/bus_timetable_test.dart
@@ -14,18 +14,18 @@ void main() {
           schedules: [
             BusEntry(
               time: '11:00', // past (before fixedNow 12:00)
-              direction: BusDirection.fromChitose,
-              destination: '千歳科技大',
+              boardingStopId: 'chitose',
+              destination: '科技大',
             ),
             BusEntry(
               time: '13:00', // future (after fixedNow 12:00)
-              direction: BusDirection.fromChitose,
-              destination: '千歳科技大',
+              boardingStopId: 'chitose',
+              destination: '科技大',
             ),
           ],
         );
 
-        final result = timetable.nextBus(BusDirection.fromChitose, now: fixedNow);
+        final result = timetable.nextBus('chitose', now: fixedNow);
         expect(result, isNotNull);
         expect(result!.time, '13:00');
       });
@@ -37,13 +37,13 @@ void main() {
           schedules: [
             BusEntry(
               time: '11:00',
-              direction: BusDirection.fromChitose,
-              destination: '千歳科技大',
+              boardingStopId: 'chitose',
+              destination: '科技大',
             ),
           ],
         );
 
-        final result = timetable.nextBus(BusDirection.fromChitose, now: fixedNow);
+        final result = timetable.nextBus('chitose', now: fixedNow);
         expect(result, isNull);
       });
 
@@ -54,18 +54,18 @@ void main() {
           schedules: [
             BusEntry(
               time: '13:00',
-              direction: BusDirection.fromMinamiChitose,
+              boardingStopId: 'minamiChitose',
               destination: '南千歳',
             ),
             BusEntry(
               time: '13:00',
-              direction: BusDirection.fromChitose,
-              destination: '千歳科技大',
+              boardingStopId: 'chitose',
+              destination: '科技大',
             ),
           ],
         );
 
-        final result = timetable.nextBus(BusDirection.fromHonbuto, now: fixedNow);
+        final result = timetable.nextBus('honbuto', now: fixedNow);
         expect(result, isNull);
       });
 
@@ -76,7 +76,7 @@ void main() {
           schedules: [],
         );
 
-        final result = timetable.nextBus(BusDirection.fromChitose, now: fixedNow);
+        final result = timetable.nextBus('chitose', now: fixedNow);
         expect(result, isNull);
       });
 
@@ -89,23 +89,23 @@ void main() {
           schedules: [
             BusEntry(
               time: '15:00',
-              direction: BusDirection.fromChitose,
+              boardingStopId: 'chitose',
               destination: '科技大',
             ),
             BusEntry(
               time: '13:00',
-              direction: BusDirection.fromChitose,
+              boardingStopId: 'chitose',
               destination: '科技大',
             ),
             BusEntry(
               time: '14:00',
-              direction: BusDirection.fromChitose,
+              boardingStopId: 'chitose',
               destination: '科技大',
             ),
           ],
         );
 
-        final result = timetable.nextBus(BusDirection.fromChitose, now: fixedNow);
+        final result = timetable.nextBus('chitose', now: fixedNow);
         expect(result, isNotNull);
         expect(result!.time, '13:00');
       });
@@ -120,20 +120,20 @@ void main() {
           schedules: [
             BusEntry(
               time: '10:54',
-              direction: BusDirection.fromKenkyutoToHonbuto,
+              boardingStopId: 'kenkyuto',
               destination: '科技大',
               routeLabel: '空港経由',
             ),
             BusEntry(
               time: '10:22',
-              direction: BusDirection.fromKenkyutoToHonbuto,
+              boardingStopId: 'kenkyuto',
               destination: '科技大',
               routeLabel: '直通',
             ),
           ],
         );
 
-        final result = timetable.nextBus(BusDirection.fromKenkyutoToHonbuto, now: now);
+        final result = timetable.nextBus('kenkyuto', now: now);
         expect(result, isNotNull);
         expect(result!.time, '10:22');
       });
@@ -147,25 +147,25 @@ void main() {
           schedules: [
             BusEntry(
               time: '09:30',
-              direction: BusDirection.fromChitose,
-              destination: '千歳科技大',
+              boardingStopId: 'chitose',
+              destination: '科技大',
             ),
             BusEntry(
               time: '10:00',
-              direction: BusDirection.fromMinamiChitose,
+              boardingStopId: 'minamiChitose',
               destination: '南千歳',
             ),
             BusEntry(
               time: '11:00',
-              direction: BusDirection.fromChitose,
-              destination: '千歳科技大',
+              boardingStopId: 'chitose',
+              destination: '科技大',
             ),
           ],
         );
 
-        final result = timetable.todayBuses(BusDirection.fromChitose);
+        final result = timetable.todayBuses('chitose');
         expect(result.length, 2);
-        expect(result.every((e) => e.direction == BusDirection.fromChitose), isTrue);
+        expect(result.every((e) => e.boardingStopId == 'chitose'), isTrue);
       });
 
       test('returns empty list when no buses match direction', () {
@@ -175,13 +175,13 @@ void main() {
           schedules: [
             BusEntry(
               time: '09:30',
-              direction: BusDirection.fromChitose,
-              destination: '千歳科技大',
+              boardingStopId: 'chitose',
+              destination: '科技大',
             ),
           ],
         );
 
-        final result = timetable.todayBuses(BusDirection.fromHonbuto);
+        final result = timetable.todayBuses('honbuto');
         expect(result, isEmpty);
       });
 
@@ -192,7 +192,7 @@ void main() {
           schedules: [],
         );
 
-        final result = timetable.todayBuses(BusDirection.fromChitose);
+        final result = timetable.todayBuses('chitose');
         expect(result, isEmpty);
       });
 
@@ -204,21 +204,21 @@ void main() {
           schedules: [
             BusEntry(
               time: '09:00',
-              direction: BusDirection.fromChitose,
-              destination: '千歳科技大',
+              boardingStopId: 'chitose',
+              destination: '科技大',
               weekdayOnly: true,
             ),
             BusEntry(
               time: '10:00',
-              direction: BusDirection.fromChitose,
-              destination: '千歳科技大',
+              boardingStopId: 'chitose',
+              destination: '科技大',
               weekendOnly: true,
             ),
           ],
         );
 
         final result =
-            timetable.todayBuses(BusDirection.fromChitose, now: saturday);
+            timetable.todayBuses('chitose', now: saturday);
         expect(result.length, 1);
         expect(result.first.time, '10:00');
       });
@@ -231,24 +231,24 @@ void main() {
         schedules: [
           BusEntry(
             time: '10:00',
-            direction: BusDirection.fromChitose,
-            destination: '千歳科技大',
+            boardingStopId: 'chitose',
+            destination: '科技大',
             weekendOnly: true,
           ),
           BusEntry(
             time: '09:00',
-            direction: BusDirection.fromChitose,
-            destination: '千歳科技大',
+            boardingStopId: 'chitose',
+            destination: '科技大',
             weekdayOnly: true,
           ),
           BusEntry(
             time: '11:00',
-            direction: BusDirection.fromChitose,
-            destination: '千歳科技大',
+            boardingStopId: 'chitose',
+            destination: '科技大',
           ),
           BusEntry(
             time: '08:00',
-            direction: BusDirection.fromMinamiChitose,
+            boardingStopId: 'minamiChitose',
             destination: '南千歳',
           ),
         ],
@@ -256,21 +256,21 @@ void main() {
 
       test('平日ダイヤ: weekendOnly の便を除外し時刻順に返す', () {
         final result =
-            timetable.busesFor(BusDirection.fromChitose, DayType.weekday, SeasonType.academic);
+            timetable.busesFor('chitose', DayType.weekday, SeasonType.academic);
         expect(result.map((e) => e.time), ['09:00', '11:00']);
       });
 
       test('土日祝ダイヤ: weekdayOnly の便を除外し時刻順に返す', () {
         final result = timetable.busesFor(
-            BusDirection.fromChitose, DayType.weekendHoliday, SeasonType.academic);
+            'chitose', DayType.weekendHoliday, SeasonType.academic);
         expect(result.map((e) => e.time), ['10:00', '11:00']);
       });
 
       test('指定方向の便のみ返す', () {
         final result = timetable.busesFor(
-            BusDirection.fromMinamiChitose, DayType.weekday, SeasonType.academic);
+            'minamiChitose', DayType.weekday, SeasonType.academic);
         expect(result.length, 1);
-        expect(result.first.direction, BusDirection.fromMinamiChitose);
+        expect(result.first.boardingStopId, 'minamiChitose');
       });
     });
   });

--- a/flutter_app/test/unit/domain/japanese_holiday_test.dart
+++ b/flutter_app/test/unit/domain/japanese_holiday_test.dart
@@ -106,7 +106,7 @@ void main() {
       schedules: const [
         BusEntry(
           time: '08:10',
-          direction: BusDirection.fromChitose,
+          boardingStopId: 'chitose',
           destination: '科技大',
           routeLabel: '直通',
           weekdayOnly: true,
@@ -114,14 +114,14 @@ void main() {
         ),
         BusEntry(
           time: '08:18',
-          direction: BusDirection.fromChitose,
+          boardingStopId: 'chitose',
           destination: '科技大',
           routeLabel: '空港経由',
           weekendOnly: true,
         ),
         BusEntry(
           time: '07:20',
-          direction: BusDirection.fromChitose,
+          boardingStopId: 'chitose',
           destination: '科技大',
           routeLabel: '空港経由',
         ),
@@ -130,7 +130,7 @@ void main() {
 
     test('8/11（山の日・学休期）は直通便が出ない', () {
       final buses = timetable.todayBuses(
-        BusDirection.fromChitose,
+        'chitose',
         now: DateTime(2026, 8, 11, 5, 0),
       );
       expect(buses.map((e) => e.time), ['07:20', '08:18']);
@@ -139,7 +139,7 @@ void main() {
 
     test('8/12（平日・学休期）は直通便が出る', () {
       final buses = timetable.todayBuses(
-        BusDirection.fromChitose,
+        'chitose',
         now: DateTime(2026, 8, 12, 5, 0),
       );
       expect(buses.map((e) => e.time), ['07:20', '08:10']);

--- a/flutter_app/test/unit/domain/lecture_period_test.dart
+++ b/flutter_app/test/unit/domain/lecture_period_test.dart
@@ -112,7 +112,7 @@ void main() {
     test('arrivals に honbuto あり → 対応する講時を返す', () {
       final bus = BusEntry(
         time: '08:30',
-        direction: BusDirection.fromChitose,
+        boardingStopId: 'chitose',
         destination: '本部棟',
         arrivals: const {'honbuto': '08:59'},
       );
@@ -122,7 +122,7 @@ void main() {
     test('arrivals に honbuto なし → null', () {
       final bus = BusEntry(
         time: '08:30',
-        direction: BusDirection.fromKenkyutoToStation,
+        boardingStopId: 'kenkyuto',
         destination: '千歳駅',
         arrivals: const {'chitose': '09:00'},
       );
@@ -132,7 +132,7 @@ void main() {
     test('arrivals が空 → null', () {
       final bus = BusEntry(
         time: '08:30',
-        direction: BusDirection.fromChitose,
+        boardingStopId: 'chitose',
         destination: '本部棟',
       );
       expect(LecturePeriodCalculator.forBus(bus), isNull);

--- a/flutter_app/test/unit/domain/notification_key_test.dart
+++ b/flutter_app/test/unit/domain/notification_key_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kagi_bus/domain/entities/bus_schedule.dart';
+
+void main() {
+  // 通知キーは SharedPreferences に保存され、OS へ予約した通知の ID の元になる。
+  // 変えると既存の予約を引き当てられず、キャンセルできない通知が残る。
+  test('通知キーが #177 以前（BusDirection.name）と同じ文字列になる', () {
+    // 旧: '${BusDirection.xxx.name}_${time}'
+    final cases = {
+      ('chitose', '科技大'): 'fromChitose_07:20',
+      ('minamiChitose', '科技大'): 'fromMinamiChitose_07:20',
+      ('kenkyuto', '科技大'): 'fromKenkyutoToHonbuto_07:20',
+      ('kenkyuto', '千歳駅'): 'fromKenkyutoToStation_07:20',
+      ('honbuto', '千歳駅'): 'fromHonbuto_07:20',
+    };
+    for (final e in cases.entries) {
+      final entry = BusEntry(
+          time: '07:20',
+          boardingStopId: e.key.$1,
+          destination: e.key.$2);
+      expect(entry.notificationKey, e.value, reason: '${e.key}');
+    }
+  });
+
+  test('該当が無い停留所は 乗車地_行き先_時刻 になる', () {
+    const entry = BusEntry(
+        time: '07:23', boardingStopId: 'morimoto', destination: '科技大');
+    expect(entry.notificationKey, 'morimoto_科技大_07:23');
+  });
+}

--- a/flutter_app/test/unit/domain/season_type_test.dart
+++ b/flutter_app/test/unit/domain/season_type_test.dart
@@ -94,7 +94,7 @@ void main() {
     BusEntry entry({bool academicOnly = false, bool vacationOnly = false}) =>
         BusEntry(
           time: '09:00',
-          direction: BusDirection.fromChitose,
+          boardingStopId: 'chitose',
           destination: '科技大',
           academicOnly: academicOnly,
           vacationOnly: vacationOnly,
@@ -121,7 +121,7 @@ void main() {
     test('運行日フラグと期別フラグは AND で効く', () {
       const e = BusEntry(
         time: '09:00',
-        direction: BusDirection.fromChitose,
+        boardingStopId: 'chitose',
         destination: '科技大',
         weekdayOnly: true,
         vacationOnly: true,
@@ -151,7 +151,7 @@ void main() {
       schedules: const [
         BusEntry(
           time: '07:14',
-          direction: BusDirection.fromChitose,
+          boardingStopId: 'chitose',
           destination: '科技大',
           routeLabel: '直通',
           weekdayOnly: true,
@@ -159,7 +159,7 @@ void main() {
         ),
         BusEntry(
           time: '08:10',
-          direction: BusDirection.fromChitose,
+          boardingStopId: 'chitose',
           destination: '科技大',
           routeLabel: '直通',
           weekdayOnly: true,
@@ -167,7 +167,7 @@ void main() {
         ),
         BusEntry(
           time: '07:20',
-          direction: BusDirection.fromChitose,
+          boardingStopId: 'chitose',
           destination: '科技大',
           routeLabel: '空港経由',
         ),
@@ -176,7 +176,7 @@ void main() {
 
     test('授業期の平日: 授業期便と共通便のみ', () {
       final result = timetable.busesFor(
-        BusDirection.fromChitose,
+        'chitose',
         DayType.weekday,
         SeasonType.academic,
       );
@@ -185,7 +185,7 @@ void main() {
 
     test('学休期の平日: 学休期便と共通便のみ', () {
       final result = timetable.busesFor(
-        BusDirection.fromChitose,
+        'chitose',
         DayType.weekday,
         SeasonType.vacation,
       );
@@ -194,7 +194,7 @@ void main() {
 
     test('学休期の土日祝: 直通便（平日限定）は消える', () {
       final result = timetable.busesFor(
-        BusDirection.fromChitose,
+        'chitose',
         DayType.weekendHoliday,
         SeasonType.vacation,
       );
@@ -203,7 +203,7 @@ void main() {
 
     test('todayBuses: 年末年始は空リスト', () {
       final result = timetable.todayBuses(
-        BusDirection.fromChitose,
+        'chitose',
         now: DateTime(2026, 1, 1, 6, 0),
       );
       expect(result, isEmpty);
@@ -211,7 +211,7 @@ void main() {
 
     test('todayBuses: 学休期の平日は学休期ダイヤになる', () {
       final result = timetable.todayBuses(
-        BusDirection.fromChitose,
+        'chitose',
         now: DateTime(2026, 8, 3, 6, 0),
       );
       expect(result.map((e) => e.time), ['07:20', '08:10']);
@@ -219,7 +219,7 @@ void main() {
 
     test('nextBus: 学休期は授業期限定便を返さない', () {
       final next = timetable.nextBus(
-        BusDirection.fromChitose,
+        'chitose',
         now: DateTime(2026, 8, 3, 7, 0),
       );
       expect(next?.time, '07:20');

--- a/flutter_app/test/unit/presentation/notification_viewmodel_test.dart
+++ b/flutter_app/test/unit/presentation/notification_viewmodel_test.dart
@@ -66,7 +66,7 @@ final _fixedNow = DateTime(2026, 1, 15, 12, 0, 0);
 // ---- テスト用の BusTimetable ヘルパー ----
 
 /// 指定した direction で未来時刻のバスを含む BusTimetable を生成する
-BusTimetable futureTimetable(BusDirection direction) {
+BusTimetable futureTimetable(String stopId) {
   final future1 = _fixedNow.add(const Duration(hours: 1));
   final future2 = _fixedNow.add(const Duration(hours: 2));
   final future3 = _fixedNow.add(const Duration(hours: 3));
@@ -78,16 +78,16 @@ BusTimetable futureTimetable(BusDirection direction) {
     validFrom: '2026-01-01',
     validTo: '2026-12-31',
     schedules: [
-      BusEntry(time: fmt(future1), direction: direction, destination: '千歳科技大'),
-      BusEntry(time: fmt(future2), direction: direction, destination: '千歳科技大'),
-      BusEntry(time: fmt(future3), direction: direction, destination: '千歳科技大'),
-      BusEntry(time: fmt(future4), direction: direction, destination: '千歳科技大'),
+      BusEntry(time: fmt(future1), boardingStopId: stopId, destination: '科技大'),
+      BusEntry(time: fmt(future2), boardingStopId: stopId, destination: '科技大'),
+      BusEntry(time: fmt(future3), boardingStopId: stopId, destination: '科技大'),
+      BusEntry(time: fmt(future4), boardingStopId: stopId, destination: '科技大'),
     ],
   );
 }
 
 /// 過去時刻のみのバスを含む BusTimetable を生成する
-BusTimetable pastTimetable(BusDirection direction) {
+BusTimetable pastTimetable(String stopId) {
   final past1 = _fixedNow.subtract(const Duration(hours: 2));
   final past2 = _fixedNow.subtract(const Duration(hours: 1));
   String fmt(DateTime dt) =>
@@ -97,8 +97,8 @@ BusTimetable pastTimetable(BusDirection direction) {
     validFrom: '2026-01-01',
     validTo: '2026-12-31',
     schedules: [
-      BusEntry(time: fmt(past1), direction: direction, destination: '千歳科技大'),
-      BusEntry(time: fmt(past2), direction: direction, destination: '千歳科技大'),
+      BusEntry(time: fmt(past1), boardingStopId: stopId, destination: '科技大'),
+      BusEntry(time: fmt(past2), boardingStopId: stopId, destination: '科技大'),
     ],
   );
 }
@@ -108,7 +108,7 @@ ProviderContainer makeContainer({
   required FakeNotificationService service,
   NotificationSettings? initialSettings,
   BusTimetable? timetable,
-  BusDirection direction = BusDirection.fromChitose,
+  String stopId = 'chitose',
 }) {
   final repo = FakeNotificationSettingsRepository(initialSettings);
 
@@ -126,7 +126,7 @@ ProviderContainer makeContainer({
             ScheduleResult(
               data: ScheduleResponse(
                 updatedAt: '2026-01-01',
-                current: futureTimetable(direction),
+                current: futureTimetable(stopId),
               ),
             ),
           ),
@@ -170,11 +170,11 @@ BusTimetable mixedDirectionTimetable() {
     schedules: [
       BusEntry(
           time: fmt(future1),
-          direction: BusDirection.fromChitose,
-          destination: '千歳科技大'),
+          boardingStopId: 'chitose',
+          destination: '科技大'),
       BusEntry(
           time: fmt(future2),
-          direction: BusDirection.fromHonbuto,
+          boardingStopId: 'honbuto',
           destination: '千歳駅'),
     ],
   );
@@ -235,7 +235,7 @@ void main() {
             '${dt.hour.toString().padLeft(2, '0')}:${dt.minute.toString().padLeft(2, '0')}';
         final futureBus = BusEntry(
           time: fmt(futureTime),
-          direction: BusDirection.fromChitose,
+          boardingStopId: 'chitose',
           destination: '千歳駅',
         );
         final key = NotificationSettingsNotifier.busKey(futureBus);
@@ -307,7 +307,7 @@ void main() {
             '${dt.hour.toString().padLeft(2, '0')}:${dt.minute.toString().padLeft(2, '0')}';
         final futureBus = BusEntry(
           time: fmt(futureTime),
-          direction: BusDirection.fromChitose,
+          boardingStopId: 'chitose',
           destination: '千歳駅',
         );
         final key = NotificationSettingsNotifier.busKey(futureBus);
@@ -402,7 +402,7 @@ void main() {
             '${dt.hour.toString().padLeft(2, '0')}:${dt.minute.toString().padLeft(2, '0')}';
         return BusEntry(
           time: fmt(future),
-          direction: BusDirection.fromChitose,
+          boardingStopId: 'chitose',
           destination: '千歳駅',
         );
       }
@@ -464,7 +464,7 @@ void main() {
             '${dt.hour.toString().padLeft(2, '0')}:${dt.minute.toString().padLeft(2, '0')}';
         final pastBus = BusEntry(
           time: fmt(past),
-          direction: BusDirection.fromChitose,
+          boardingStopId: 'chitose',
           destination: '千歳駅',
         );
         final container = makeContainer(
@@ -514,7 +514,7 @@ void main() {
             '${dt.hour.toString().padLeft(2, '0')}:${dt.minute.toString().padLeft(2, '0')}';
         final futureBus = BusEntry(
           time: fmt(futureTime),
-          direction: BusDirection.fromChitose,
+          boardingStopId: 'chitose',
           destination: '千歳駅',
         );
         final key = NotificationSettingsNotifier.busKey(futureBus);
@@ -542,7 +542,7 @@ void main() {
 
         final trackedCalls = service.scheduledCalls
             .where((c) => c.bus.time == futureBus.time &&
-                          c.bus.direction == futureBus.direction)
+                          c.bus.boardingStopId == futureBus.boardingStopId)
             .toList();
         expect(trackedCalls, isNotEmpty,
             reason: '選択済み便が再スケジュールされるべき');

--- a/flutter_app/test/unit/presentation/schedule_viewmodel_test.dart
+++ b/flutter_app/test/unit/presentation/schedule_viewmodel_test.dart
@@ -179,21 +179,10 @@ void main() {
   });
 
   group('再試行が固まらない', () {
-    test('取得も失敗しキャッシュも解釈できないとき、AsyncError で止まる', () async {
+    test('取得も失敗しキャッシュ読み出しも失敗するとき、AsyncError で止まる', () async {
       // getCached が投げると refresh の catch を突き抜け、
       // AsyncLoading のまま戻れないスピナーになる
-      final poisoned = ScheduleResponseModel(
-        updatedAt: '2026-08-10',
-        current: const BusTimetableModel(
-          trips: [
-            TripModel(
-              destination: '長都駅',
-              stops: [StopTimeModel(id: 'chitose', time: '21:00')],
-            ),
-          ],
-        ),
-      );
-      fakeLocalSource.preload(poisoned);
+      fakeLocalSource.failOnLoad = true;
       when(() => mockSource.fetchSchedule(any()))
           .thenThrow(Exception('network error'));
 
@@ -204,11 +193,10 @@ void main() {
         await container.read(scheduleViewModelProvider.future);
       } catch (_) {}
 
-      // 修正前はここで getCached() の例外が refresh を突き抜けていた
       await container.read(scheduleViewModelProvider.notifier).refresh();
 
-      final state = container.read(scheduleViewModelProvider);
-      expect(state, isA<AsyncError<ScheduleResult>>(),
+      expect(container.read(scheduleViewModelProvider),
+          isA<AsyncError<ScheduleResult>>(),
           reason: 'AsyncLoading のまま残ってはいけない');
     });
   });

--- a/flutter_app/test/widget/golden/next_bus_card_golden_test.dart
+++ b/flutter_app/test/widget/golden/next_bus_card_golden_test.dart
@@ -15,8 +15,8 @@ final _timetableWithNextBus = BusTimetable(
   schedules: [
     BusEntry(
       time: '23:59',
-      direction: BusDirection.fromChitose,
-      destination: '千歳科技大',
+      boardingStopId: 'chitose',
+      destination: '科技大',
       arrivals: {'kenkyuto': '00:10', 'honbuto': '00:15'},
     ),
   ],
@@ -58,7 +58,7 @@ void main() {
         child: _buildTestApp(
           child: NextBusDisplay(
             timetable: _timetableWithNextBus,
-            direction: BusDirection.fromChitose,
+            stopId: 'chitose',
           ),
         ),
       ),
@@ -85,7 +85,7 @@ void main() {
         child: _buildTestApp(
           child: NextBusDisplay(
             timetable: _timetableNoMoreBus,
-            direction: BusDirection.fromChitose,
+            stopId: 'chitose',
           ),
         ),
       ),

--- a/flutter_app/test/widget/golden/schedule_list_golden_test.dart
+++ b/flutter_app/test/widget/golden/schedule_list_golden_test.dart
@@ -16,12 +16,12 @@ final _timetableForNextHighlight = BusTimetable(
   schedules: [
     BusEntry(
       time: '00:01',
-      direction: BusDirection.fromChitose,
+      boardingStopId: 'chitose',
       destination: '千歳科技大',
     ),
     BusEntry(
       time: '23:59',
-      direction: BusDirection.fromChitose,
+      boardingStopId: 'chitose',
       destination: '千歳科技大',
     ),
   ],
@@ -34,17 +34,17 @@ final _timetableAllPast = BusTimetable(
   schedules: [
     BusEntry(
       time: '00:01',
-      direction: BusDirection.fromChitose,
+      boardingStopId: 'chitose',
       destination: '千歳科技大',
     ),
     BusEntry(
       time: '00:02',
-      direction: BusDirection.fromChitose,
+      boardingStopId: 'chitose',
       destination: '千歳科技大',
     ),
     BusEntry(
       time: '00:03',
-      direction: BusDirection.fromChitose,
+      boardingStopId: 'chitose',
       destination: '千歳科技大',
     ),
   ],
@@ -79,7 +79,7 @@ void main() {
         child: _buildTestApp(
           child: ScheduleList(
             timetable: _timetableForNextHighlight,
-            direction: BusDirection.fromChitose,
+            stopId: 'chitose',
           ),
         ),
       ),
@@ -107,7 +107,7 @@ void main() {
         child: _buildTestApp(
           child: ScheduleList(
             timetable: _timetableAllPast,
-            direction: BusDirection.fromChitose,
+            stopId: 'chitose',
           ),
         ),
       ),

--- a/flutter_app/test/widget/home_screen_test.dart
+++ b/flutter_app/test/widget/home_screen_test.dart
@@ -390,14 +390,14 @@ void main() {
               schedules: const [
                 BusEntry(
                   time: '09:00',
-                  direction: BusDirection.fromChitose,
-                  destination: '千歳科技大',
+                  boardingStopId: 'chitose',
+                  destination: '科技大',
                   weekdayOnly: true,
                 ),
                 BusEntry(
                   time: '10:00',
-                  direction: BusDirection.fromChitose,
-                  destination: '千歳科技大',
+                  boardingStopId: 'chitose',
+                  destination: '科技大',
                   weekendOnly: true,
                 ),
               ],
@@ -640,7 +640,7 @@ void main() {
         scheduleVM.complete();
         await tester.pump();
 
-        final segmentedFinder = find.byType(SegmentedButton<BusDirection>);
+        final segmentedFinder = find.byType(SegmentedButton<String>);
         expect(segmentedFinder, findsOneWidget);
 
         // バグが再現すると高さが 0 になる

--- a/flutter_app/test/widget/next_bus_display_test.dart
+++ b/flutter_app/test/widget/next_bus_display_test.dart
@@ -22,15 +22,15 @@ void main() {
         schedules: [
           BusEntry(
             time: busTime,
-            direction: BusDirection.fromChitose,
-            destination: '千歳科技大',
+            boardingStopId: 'chitose',
+            destination: '科技大',
           ),
         ],
       );
 
       await tester.pumpWidget(
         _wrap(NextBusDisplay(
-            timetable: timetable, direction: BusDirection.fromChitose)),
+            timetable: timetable, stopId: 'chitose')),
       );
 
       // Departure time text (HH:MM format)
@@ -62,15 +62,15 @@ void main() {
         schedules: [
           BusEntry(
             time: busTime,
-            direction: BusDirection.fromChitose,
-            destination: '千歳科技大',
+            boardingStopId: 'chitose',
+            destination: '科技大',
           ),
         ],
       );
 
       await tester.pumpWidget(
         _wrap(NextBusDisplay(
-            timetable: timetable, direction: BusDirection.fromChitose)),
+            timetable: timetable, stopId: 'chitose')),
       );
 
       // minutesFromNow() ≤ 5 → label is 'あと N 分' or '発車中', color is red.
@@ -100,15 +100,15 @@ void main() {
         schedules: [
           BusEntry(
             time: nearFuture,
-            direction: BusDirection.fromChitose,
-            destination: '千歳科技大',
+            boardingStopId: 'chitose',
+            destination: '科技大',
           ),
         ],
       );
 
       await tester.pumpWidget(
         _wrap(NextBusDisplay(
-            timetable: timetable, direction: BusDirection.fromChitose)),
+            timetable: timetable, stopId: 'chitose')),
       );
 
       // Label is either '発車中' (minutes == 0) or 'あと 1 分' (minutes == 1).
@@ -131,7 +131,7 @@ void main() {
 
       await tester.pumpWidget(
         _wrap(NextBusDisplay(
-            timetable: timetable, direction: BusDirection.fromChitose)),
+            timetable: timetable, stopId: 'chitose')),
       );
 
       expect(find.text('本日の運行は終了しました'), findsOneWidget);
@@ -145,15 +145,15 @@ void main() {
         schedules: [
           BusEntry(
             time: '00:01',
-            direction: BusDirection.fromChitose,
-            destination: '千歳科技大',
+            boardingStopId: 'chitose',
+            destination: '科技大',
           ),
         ],
       );
 
       await tester.pumpWidget(
         _wrap(NextBusDisplay(
-            timetable: timetable, direction: BusDirection.fromChitose)),
+            timetable: timetable, stopId: 'chitose')),
       );
 
       expect(find.text('本日の運行は終了しました'), findsOneWidget);
@@ -167,15 +167,15 @@ void main() {
         schedules: [
           BusEntry(
             time: busTime,
-            direction: BusDirection.fromChitose,
-            destination: '千歳科技大',
+            boardingStopId: 'chitose',
+            destination: '科技大',
           ),
         ],
       );
 
       await tester.pumpWidget(
         _wrap(NextBusDisplay(
-            timetable: timetable, direction: BusDirection.fromChitose)),
+            timetable: timetable, stopId: 'chitose')),
       );
 
       expect(find.text('あと 59 分'), findsOneWidget);
@@ -189,15 +189,15 @@ void main() {
         schedules: [
           BusEntry(
             time: busTime,
-            direction: BusDirection.fromChitose,
-            destination: '千歳科技大',
+            boardingStopId: 'chitose',
+            destination: '科技大',
           ),
         ],
       );
 
       await tester.pumpWidget(
         _wrap(NextBusDisplay(
-            timetable: timetable, direction: BusDirection.fromChitose)),
+            timetable: timetable, stopId: 'chitose')),
       );
 
       expect(find.text('あと 1:00'), findsOneWidget);
@@ -211,15 +211,15 @@ void main() {
         schedules: [
           BusEntry(
             time: busTime,
-            direction: BusDirection.fromChitose,
-            destination: '千歳科技大',
+            boardingStopId: 'chitose',
+            destination: '科技大',
           ),
         ],
       );
 
       await tester.pumpWidget(
         _wrap(NextBusDisplay(
-            timetable: timetable, direction: BusDirection.fromChitose)),
+            timetable: timetable, stopId: 'chitose')),
       );
 
       expect(find.text('あと 1:30'), findsOneWidget);
@@ -234,7 +234,7 @@ void main() {
         schedules: [
           BusEntry(
             time: busTime,
-            direction: BusDirection.fromChitose,
+            boardingStopId: 'chitose',
             destination: '科技大',
             platformNumber: '5番',
           ),
@@ -244,7 +244,7 @@ void main() {
       await tester.pumpWidget(
         _wrap(NextBusDisplay(
           timetable: timetable,
-          direction: BusDirection.fromChitose,
+          stopId: 'chitose',
           showPlatform: true,
         )),
       );
@@ -262,8 +262,8 @@ void main() {
         schedules: [
           BusEntry(
             time: busTime,
-            direction: BusDirection.fromChitose,
-            destination: '千歳科技大',
+            boardingStopId: 'chitose',
+            destination: '科技大',
             arrivals: {'kenkyuto': arrivalTime},
           ),
         ],
@@ -271,7 +271,7 @@ void main() {
 
       await tester.pumpWidget(
         _wrap(NextBusDisplay(
-            timetable: timetable, direction: BusDirection.fromChitose)),
+            timetable: timetable, stopId: 'chitose')),
       );
 
       expect(find.text('研究棟 着'), findsOneWidget);

--- a/flutter_app/test/widget/schedule_list_test.dart
+++ b/flutter_app/test/widget/schedule_list_test.dart
@@ -89,7 +89,7 @@ void main() {
 
       await tester.pumpWidget(
         _wrap(ScheduleList(
-            timetable: timetable, direction: BusDirection.fromChitose)),
+            timetable: timetable, stopId: 'chitose')),
       );
 
       expect(find.text('時刻表データなし'), findsOneWidget);
@@ -104,18 +104,18 @@ void main() {
         schedules: [
           BusEntry(
               time: t1,
-              direction: BusDirection.fromChitose,
+              boardingStopId: 'chitose',
               destination: '千歳科技大'),
           BusEntry(
               time: t2,
-              direction: BusDirection.fromChitose,
+              boardingStopId: 'chitose',
               destination: '千歳科技大'),
         ],
       );
 
       await tester.pumpWidget(
         _wrap(ScheduleList(
-            timetable: timetable, direction: BusDirection.fromChitose)),
+            timetable: timetable, stopId: 'chitose')),
       );
 
       // When t1 == t2 (both capped at 23:58 near midnight), two widgets share
@@ -138,14 +138,14 @@ void main() {
         schedules: [
           BusEntry(
               time: nextTime,
-              direction: BusDirection.fromChitose,
+              boardingStopId: 'chitose',
               destination: '千歳科技大'),
         ],
       );
 
       await tester.pumpWidget(
         _wrap(ScheduleList(
-            timetable: timetable, direction: BusDirection.fromChitose)),
+            timetable: timetable, stopId: 'chitose')),
       );
 
       expect(find.text('◀ NEXT'), findsOneWidget);
@@ -166,14 +166,14 @@ void main() {
         schedules: [
           BusEntry(
               time: pastTime,
-              direction: BusDirection.fromChitose,
+              boardingStopId: 'chitose',
               destination: '千歳科技大'),
         ],
       );
 
       await tester.pumpWidget(
         _wrap(ScheduleList(
-            timetable: timetable, direction: BusDirection.fromChitose)),
+            timetable: timetable, stopId: 'chitose')),
       );
 
       final timeText = tester.widget<Text>(find.text(pastTime));
@@ -192,18 +192,18 @@ void main() {
         schedules: [
           BusEntry(
               time: t1,
-              direction: BusDirection.fromChitose,
+              boardingStopId: 'chitose',
               destination: '千歳科技大'),
           BusEntry(
               time: t2,
-              direction: BusDirection.fromChitose,
+              boardingStopId: 'chitose',
               destination: '千歳科技大'),
         ],
       );
 
       await tester.pumpWidget(
         _wrap(ScheduleList(
-            timetable: timetable, direction: BusDirection.fromChitose)),
+            timetable: timetable, stopId: 'chitose')),
       );
 
       // t2 is neither next nor past → textColor should be 0xFFCCCCCC.
@@ -225,7 +225,7 @@ void main() {
         schedules: [
           BusEntry(
             time: busTime,
-            direction: BusDirection.fromChitose,
+            boardingStopId: 'chitose',
             destination: '千歳科技大',
             arrivals: {'kenkyuto': arrivalTime},
           ),
@@ -234,7 +234,7 @@ void main() {
 
       await tester.pumpWidget(
         _wrap(ScheduleList(
-            timetable: timetable, direction: BusDirection.fromChitose)),
+            timetable: timetable, stopId: 'chitose')),
       );
 
       // タップ前は到着情報が非表示
@@ -257,7 +257,7 @@ void main() {
         schedules: [
           BusEntry(
             time: busTime,
-            direction: BusDirection.fromChitose,
+            boardingStopId: 'chitose',
             destination: '千歳科技大',
             arrivals: {'kenkyuto': arrivalTime},
           ),
@@ -266,7 +266,7 @@ void main() {
 
       await tester.pumpWidget(
         _wrap(ScheduleList(
-            timetable: timetable, direction: BusDirection.fromChitose)),
+            timetable: timetable, stopId: 'chitose')),
       );
 
       // 1回目タップ → 展開
@@ -289,12 +289,12 @@ void main() {
           schedules: [
             BusEntry(
                 time: busTime,
-                direction: BusDirection.fromChitose,
+                boardingStopId: 'chitose',
                 destination: '千歳科技大'),
           ],
         );
         await tester.pumpWidget(_wrapWithNotification(
-          ScheduleList(timetable: timetable, direction: BusDirection.fromChitose),
+          ScheduleList(timetable: timetable, stopId: 'chitose'),
           NotificationSettings(enabled: true),
         ));
         await tester.pump();
@@ -310,12 +310,12 @@ void main() {
           schedules: [
             BusEntry(
                 time: busTime,
-                direction: BusDirection.fromChitose,
+                boardingStopId: 'chitose',
                 destination: '千歳科技大'),
           ],
         );
         await tester.pumpWidget(_wrapWithNotification(
-          ScheduleList(timetable: timetable, direction: BusDirection.fromChitose),
+          ScheduleList(timetable: timetable, stopId: 'chitose'),
           NotificationSettings(enabled: false),
         ));
         await tester.pump();
@@ -332,12 +332,12 @@ void main() {
           schedules: [
             BusEntry(
                 time: pastTime,
-                direction: BusDirection.fromChitose,
+                boardingStopId: 'chitose',
                 destination: '千歳科技大'),
           ],
         );
         await tester.pumpWidget(_wrapWithNotification(
-          ScheduleList(timetable: timetable, direction: BusDirection.fromChitose),
+          ScheduleList(timetable: timetable, stopId: 'chitose'),
           NotificationSettings(enabled: true),
         ));
         await tester.pump();
@@ -350,7 +350,7 @@ void main() {
         final busTime = safeFutureHhmm(60);
         final bus = BusEntry(
             time: busTime,
-            direction: BusDirection.fromChitose,
+            boardingStopId: 'chitose',
             destination: '千歳科技大');
         final key = NotificationSettingsNotifier.busKey(bus);
         final timetable = BusTimetable(
@@ -359,7 +359,7 @@ void main() {
           schedules: [bus],
         );
         await tester.pumpWidget(_wrapWithNotification(
-          ScheduleList(timetable: timetable, direction: BusDirection.fromChitose),
+          ScheduleList(timetable: timetable, stopId: 'chitose'),
           NotificationSettings(enabled: true, scheduledBusKeys: {key}),
         ));
         await tester.pump();
@@ -376,12 +376,12 @@ void main() {
           schedules: [
             BusEntry(
                 time: busTime,
-                direction: BusDirection.fromChitose,
+                boardingStopId: 'chitose',
                 destination: '千歳科技大'),
           ],
         );
         await tester.pumpWidget(_wrapWithNotification(
-          ScheduleList(timetable: timetable, direction: BusDirection.fromChitose),
+          ScheduleList(timetable: timetable, stopId: 'chitose'),
           NotificationSettings(enabled: true),
         ));
         await tester.pump();
@@ -394,7 +394,7 @@ void main() {
         final busTime = safeFutureHhmm(60);
         final bus = BusEntry(
             time: busTime,
-            direction: BusDirection.fromChitose,
+            boardingStopId: 'chitose',
             destination: '千歳科技大');
         final timetable = BusTimetable(
           validFrom: '2024-01-01',
@@ -415,7 +415,7 @@ void main() {
             theme: buildTestTheme(),
             home: Scaffold(
               body: ScheduleList(
-                  timetable: timetable, direction: BusDirection.fromChitose),
+                  timetable: timetable, stopId: 'chitose'),
             ),
           ),
         ));
@@ -440,12 +440,12 @@ void main() {
           schedules: [
             BusEntry(
                 time: busTime,
-                direction: BusDirection.fromChitose,
+                boardingStopId: 'chitose',
                 destination: '千歳科技大'),
           ],
         );
         await tester.pumpWidget(_wrapWithNotification(
-          ScheduleList(timetable: timetable, direction: BusDirection.fromChitose),
+          ScheduleList(timetable: timetable, stopId: 'chitose'),
           NotificationSettings(enabled: true, minutesBefore: minutesBefore),
         ));
         await tester.pump();
@@ -464,12 +464,12 @@ void main() {
           schedules: [
             BusEntry(
                 time: busTime,
-                direction: BusDirection.fromChitose,
+                boardingStopId: 'chitose',
                 destination: '千歳科技大'),
           ],
         );
         await tester.pumpWidget(_wrapWithNotification(
-          ScheduleList(timetable: timetable, direction: BusDirection.fromChitose),
+          ScheduleList(timetable: timetable, stopId: 'chitose'),
           NotificationSettings(enabled: true, minutesBefore: minutesBefore),
         ));
         await tester.pump();
@@ -486,7 +486,7 @@ void main() {
         schedules: [
           BusEntry(
             time: busTime,
-            direction: BusDirection.fromChitose,
+            boardingStopId: 'chitose',
             destination: '千歳科技大',
           ),
         ],
@@ -494,7 +494,7 @@ void main() {
 
       await tester.pumpWidget(
         _wrap(ScheduleList(
-            timetable: timetable, direction: BusDirection.fromChitose)),
+            timetable: timetable, stopId: 'chitose')),
       );
 
       await tester.tap(find.text(busTime));
@@ -511,7 +511,7 @@ void main() {
           schedules: [
             BusEntry(
               time: _futureDeparture,
-              direction: BusDirection.fromChitose,
+              boardingStopId: 'chitose',
               destination: '千歳科技大',
               arrivals: const {'honbuto': '08:59'},
             ),
@@ -519,7 +519,7 @@ void main() {
         );
         await tester.pumpWidget(
           _wrap(ScheduleList(
-              timetable: timetable, direction: BusDirection.fromChitose)),
+              timetable: timetable, stopId: 'chitose')),
         );
         expect(find.text('1講'), findsOneWidget);
       });
@@ -531,7 +531,7 @@ void main() {
           schedules: [
             BusEntry(
               time: _futureDeparture,
-              direction: BusDirection.fromChitose,
+              boardingStopId: 'chitose',
               destination: '千歳科技大',
               arrivals: const {'honbuto': '09:00'},
             ),
@@ -539,7 +539,7 @@ void main() {
         );
         await tester.pumpWidget(
           _wrap(ScheduleList(
-              timetable: timetable, direction: BusDirection.fromChitose)),
+              timetable: timetable, stopId: 'chitose')),
         );
         expect(find.text('2講'), findsOneWidget);
       });
@@ -551,7 +551,7 @@ void main() {
           schedules: [
             BusEntry(
               time: _futureDeparture,
-              direction: BusDirection.fromChitose,
+              boardingStopId: 'chitose',
               destination: '千歳科技大',
               arrivals: const {'honbuto': '16:45'},
             ),
@@ -559,7 +559,7 @@ void main() {
         );
         await tester.pumpWidget(
           _wrap(ScheduleList(
-              timetable: timetable, direction: BusDirection.fromChitose)),
+              timetable: timetable, stopId: 'chitose')),
         );
         expect(find.text('放課後'), findsOneWidget);
       });
@@ -571,7 +571,7 @@ void main() {
           schedules: [
             BusEntry(
               time: _futureDeparture,
-              direction: BusDirection.fromKenkyutoToStation,
+              boardingStopId: 'kenkyuto',
               destination: '千歳駅',
               arrivals: const {'chitose': '09:30'},
             ),
@@ -580,7 +580,7 @@ void main() {
         await tester.pumpWidget(
           _wrap(ScheduleList(
               timetable: timetable,
-              direction: BusDirection.fromKenkyutoToStation)),
+              stopId: 'kenkyuto')),
         );
         for (final label in ['1講', '2講', '昼休み', '3講', '4講', '5講', '放課後']) {
           expect(find.text(label), findsNothing);
@@ -594,14 +594,14 @@ void main() {
           schedules: [
             BusEntry(
               time: _futureDeparture,
-              direction: BusDirection.fromChitose,
+              boardingStopId: 'chitose',
               destination: '千歳科技大',
             ),
           ],
         );
         await tester.pumpWidget(
           _wrap(ScheduleList(
-              timetable: timetable, direction: BusDirection.fromChitose)),
+              timetable: timetable, stopId: 'chitose')),
         );
         for (final label in ['1講', '2講', '昼休み', '3講', '4講', '5講', '放課後']) {
           expect(find.text(label), findsNothing);
@@ -615,7 +615,7 @@ void main() {
           schedules: [
             BusEntry(
               time: _futureDeparture,
-              direction: BusDirection.fromChitose,
+              boardingStopId: 'chitose',
               destination: '千歳科技大',
               arrivals: const {'honbuto': '10:00'},
             ),
@@ -624,7 +624,7 @@ void main() {
         await tester.pumpWidget(
           _wrapWithDisplay(
             ScheduleList(
-                timetable: timetable, direction: BusDirection.fromChitose),
+                timetable: timetable, stopId: 'chitose'),
             const DisplaySettings(showLectureTags: false),
           ),
         );
@@ -641,7 +641,7 @@ void main() {
           schedules: [
             BusEntry(
               time: _futureDeparture,
-              direction: BusDirection.fromChitose,
+              boardingStopId: 'chitose',
               destination: '千歳科技大',
               arrivals: const {'honbuto': '10:00'},
             ),
@@ -649,7 +649,7 @@ void main() {
         );
         await tester.pumpWidget(
           _wrap(ScheduleList(
-              timetable: timetable, direction: BusDirection.fromChitose)),
+              timetable: timetable, stopId: 'chitose')),
         );
         // NEXT行であることを確認
         expect(find.text('◀ NEXT'), findsOneWidget);
@@ -666,19 +666,19 @@ void main() {
         schedules: const [
           BusEntry(
             time: '09:00',
-            direction: BusDirection.fromChitose,
+            boardingStopId: 'chitose',
             destination: '千歳科技大',
             weekdayOnly: true,
           ),
           BusEntry(
             time: '10:00',
-            direction: BusDirection.fromChitose,
+            boardingStopId: 'chitose',
             destination: '千歳科技大',
             weekendOnly: true,
           ),
           BusEntry(
             time: '11:00',
-            direction: BusDirection.fromChitose,
+            boardingStopId: 'chitose',
             destination: '千歳科技大',
           ),
         ],
@@ -688,7 +688,7 @@ void main() {
         await tester.pumpWidget(
           _wrap(ScheduleList(
             timetable: mixedTimetable,
-            direction: BusDirection.fromChitose,
+            stopId: 'chitose',
             dayType: DayType.weekday,
           )),
         );
@@ -702,7 +702,7 @@ void main() {
         await tester.pumpWidget(
           _wrap(ScheduleList(
             timetable: mixedTimetable,
-            direction: BusDirection.fromChitose,
+            stopId: 'chitose',
             dayType: DayType.weekendHoliday,
           )),
         );
@@ -718,7 +718,7 @@ void main() {
         await tester.pumpWidget(
           _wrap(ScheduleList(
             timetable: mixedTimetable,
-            direction: BusDirection.fromChitose,
+            stopId: 'chitose',
             dayType: DayType.weekday,
           )),
         );
@@ -734,7 +734,7 @@ void main() {
           schedules: const [
             BusEntry(
               time: '00:01',
-              direction: BusDirection.fromChitose,
+              boardingStopId: 'chitose',
               destination: '千歳科技大',
             ),
           ],
@@ -742,7 +742,7 @@ void main() {
         await tester.pumpWidget(
           _wrap(ScheduleList(
             timetable: timetable,
-            direction: BusDirection.fromChitose,
+            stopId: 'chitose',
             dayType: DayType.weekday,
           )),
         );
@@ -759,14 +759,14 @@ void main() {
           schedules: [
             BusEntry(
                 time: busTime,
-                direction: BusDirection.fromChitose,
+                boardingStopId: 'chitose',
                 destination: '千歳科技大'),
           ],
         );
         await tester.pumpWidget(_wrapWithNotification(
           ScheduleList(
             timetable: timetable,
-            direction: BusDirection.fromChitose,
+            stopId: 'chitose',
             dayType: DayType.weekday,
           ),
           NotificationSettings(enabled: true),
@@ -792,13 +792,13 @@ void main() {
         schedules: [
           ...pastTimes.map((t) => BusEntry(
                 time: t,
-                direction: BusDirection.fromChitose,
-                destination: '科技大',
+                boardingStopId: 'chitose',
+                destination: '千歳科技大',
               )),
           BusEntry(
             time: nextTime,
-            direction: BusDirection.fromChitose,
-            destination: '科技大',
+            boardingStopId: 'chitose',
+            destination: '千歳科技大',
           ),
         ],
       );
@@ -814,7 +814,7 @@ void main() {
                 height: 200,
                 child: ScheduleList(
                     timetable: timetable,
-                    direction: BusDirection.fromChitose),
+                    stopId: 'chitose'),
               ),
             ),
           ),


### PR DESCRIPTION
## 概要

Issue #177 の step 5 前半。**`BusDirection` を廃止し、乗車地（停留所 ID）で便を引くようにする。**

> [!IMPORTANT]
> **タブの構成を研究棟の形に統一した。** 研究棟だけが持っていた「行き先の切り替え」を
> 全タブの標準形にしたもので、任意の停留所は上下両方向のバスが通る以上こうなる。
> 副作用として、旧 `_DirectionTab` の3タブ（千歳駅・南千歳・本部棟）は NEXT BUS の
> 上の余白が **24px → 32px** に変わる（研究棟と同じ値）。意図した統一であり、
> 元に戻す予定は無い。
>
> 設定画面での乗車地選択・タブ生成・`FavoriteTab` の移行は次の PR。
> 受け入れ条件は「**golden 画像が無改変で通る**」こと（golden は `ScheduleList` と
> `NextBusCard` を撮っており、上記の余白はその外側にあるため影響しない）。

## なぜ

`BusDirection` は「乗車地 × 行き先」の5通りを列挙した enum で、**任意の停留所を表現できない**。

```dart
enum BusDirection {
  fromChitose, fromMinamiChitose,
  fromKenkyutoToHonbuto, fromKenkyutoToStation, fromHonbuto,
}
```

「もりもと本店前から科技大へ」を足そうとすると、停留所を増やすたびに enum が増える。#177 の目的が果たせない。

## 変更

`BusEntry.direction` を `boardingStopId` に置き換え、行き先は `destination` で絞る。

```dart
timetable.busesFor('morimoto', dayType, season, destination: '科技大')
```

**停留所だけでは絞れない。** 途中の停留所は上下両方向のバスが通るため、行き先も指定しないと逆方向の便が混ざる。`destination` は任意引数で、省略すればその停留所から乗る便すべてを返す。

- 展開を全停留所に一般化した（もりもと本店前など途中の停留所から乗る便が引ける）
- `_getArrivalOrder()` を削除した。`arrivals` が通過順のまま入るので不要になった
- `BusStop` に `shortLabel` / `displayLabel` を足した（GAS 側は #187）

## 通知キーの互換を保った

`BusEntry.notificationKey` は SharedPreferences に保存され、**OS へ予約した通知の ID の元にもなる**。変えると既存の予約を引き当てられず、キャンセルできない通知が残る。

```dart
('chitose', '科技大') => 'fromChitose',   // 旧 BusDirection.name
...
_ => '${boardingStopId}_$destination',    // 新しい停留所
```

### 実装時に取り違えていたのを検算で発見した

旧キーを JSON の文字列（`from_chitose`）だと思い込んでいたが、実際は enum 名（`fromChitose`）だった。互換を確かめるテストを書いたことで判明したため、そのまま回帰テストとして残してある。

```dart
test('通知キーが #177 以前（BusDirection.name）と同じ文字列になる', ...)
```

## 受け入れ条件の確認

```
$ flutter test
00:10 +338: All tests passed!

$ git status --short flutter_app/test/widget/golden/goldens/
（変更なし）
```

**golden 画像に一切変更が無い。** `pubspec.lock` も base と同一。

## テストの変更について

大半は `BusDirection.fromChitose` → `'chitose'` の機械的な追随。アサーションは緩めていない。判断が必要だった箇所を挙げる。

### `next_bus_display` のテストデータを実応答に合わせた

旧実装は表示名を `direction` から導いており、テストデータの `destination: '千歳科技大'` は**画面に出ていなかった**。新実装は `destination` を使うため、実際の GAS が返す `'科技大'` に直した。これにより golden は無改変で通る。

`schedule_list` は `destination` をそのまま描画しているので、データを変えると golden が変わる。こちらは元のデータのままにした。

### 「解釈できない応答」のテストを差し替えた

#184 で入れた `FormatException`（未知の行き先）は、`destination` をキーに乗車地を引く実装に紐づいたものだった。その引き当て自体が無くなったため、失敗モードが消えている。

代わりに **`getCached` が例外を投げない**という契約（#184 のレビューで interface に明記したもの）を、キャッシュ読み出しが失敗する状況で検証する形に置き換えた。

この差し替えの過程で**実装の穴が見つかった**。`getCached` の try/catch が `toEntity()` しか包んでおらず、`load()` 自体が投げると契約を満たさなかった。読み出し全体を包むよう修正している。

## 補足

`destinationLabelOf()` に一時的な分岐が残っている。研究棟から乗る場合だけ `destination`（科技大）ではなく「本部棟」と表示する現在の挙動を保つためで、次の PR で見直す。任意の停留所ではこの対応表を持てないため、行き先の出し方そのものを決め直す必要がある。

Refs #177

